### PR TITLE
Improve tutorials topic parsing

### DIFF
--- a/canonicalwebteam/discourse/parsers/docs.py
+++ b/canonicalwebteam/discourse/parsers/docs.py
@@ -575,6 +575,8 @@ class DocParser(BaseParser):
         tutorial_tables = []
 
         tables = soup.select("table:has(th:-soup-contains('Tutorials'))")
+        if soup.select("table:has(th:nth-child(2))"):
+            return
 
         for table in tables:
             table_rows = table.select("tr:has(td)")

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse",
-    version="4.0.9",
+    version="4.0.10",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url=(


### PR DESCRIPTION
An [issue was reported on Snapcraft](https://github.com/canonical-web-and-design/snapcraft.io/issues/4068).

I tracked the issue down to the table on https://forum.snapcraft.io/t/snap-tutorials/30848 having the heading “Tutorials” (as a quick fix I renamed it to “Walkthroughs”).

<assumption>
Based on the docstring I believe tutorial indexes should only have one column.
</assumption>

As such, I've added a check to see if the table has multiple columns (headers).

I am not familiar with this module, so I would greatly appreciate someone in-the-know to double-check my assumption is accurate AND the fix works :).