### PR TITLE
Handle 404 for engage pages that don't exist

### DIFF
--- a/canonicalwebteam/discourse/app.py
+++ b/canonicalwebteam/discourse/app.py
@@ -330,6 +330,9 @@ class EngagePages(BaseParser):
             single_topic[0]
         except KeyError:
             return None
+        # No metadata found if single_topic = []
+        except IndexError:
+            return None
 
         metadata = self.parse_topics(single_topic[0])
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse",
-    version="5.0.0",
+    version="5.0.1",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url=(


### PR DESCRIPTION
## Done
When data-explorer doesn't return metadata, return None, so that we can process it in the project (usually a 404)

## QA

Check that https://ubuntu-com-11940.demos.haus/engage/not-found goes to 404 instead of 500 (demo comes from [this PR](https://github.com/canonical/ubuntu.com/pull/11940))


