### PR TITLE
More flexibility to engage pages metadata checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ engage_pages = EngagePages(
     category_id=51,
     page_type="engage-pages", # one of ["engage-pages", "takeovers"]
     exclude_topics=[] # this is a list of topic ids that we want to exclude from Markdown error checks
+    additional_metadata_validation=[] # list of additional keys in the metadata table that you want to validate existence for e.g. language
 )
 ```
 

--- a/canonicalwebteam/discourse/app.py
+++ b/canonicalwebteam/discourse/app.py
@@ -293,11 +293,19 @@ class EngagePages(BaseParser):
     :param skip_posts: Skip given posts from throwing errors
     """
 
-    def __init__(self, api, category_id, page_type, exclude_topics=[]):
+    def __init__(
+        self,
+        api,
+        category_id,
+        page_type,
+        exclude_topics=[],
+        additional_metadata_validation=[],
+    ):
         self.api = api
         self.category_id = category_id
         self.page_type = page_type
         self.exclude_topics = exclude_topics
+        self.additional_metadata_validation = additional_metadata_validation
         pass
 
     def get_index(self):
@@ -518,7 +526,7 @@ class EngagePages(BaseParser):
         index_list = [item for item in self.metadata if item["tags"] in tags]
         return index_list
 
-    def engage_pages_healthcheck(self, metadata, topic_id, title=None):
+    def engage_pages_healthcheck(self, metadata, topic_id):
         """
         Check engage pages metadata (key/value table)
         for errors
@@ -538,14 +546,6 @@ class EngagePages(BaseParser):
                 "Missing topic_name on "
                 f"https://discourse.ubuntu.com/t/{topic_id}."
                 " Default discourse title will be used"
-            )
-            errors.append(error)
-
-        if "language" not in metadata:
-            error = (
-                "Missing language on "
-                f"https://discourse.ubuntu.com/t/{topic_id}."
-                " This parameter is required to render individual engage pages"
             )
             errors.append(error)
 
@@ -575,6 +575,16 @@ class EngagePages(BaseParser):
                     " with the following format: yyyy-mm-dd"
                 )
 
+        for key in self.additional_metadata_validation:
+
+            if key not in metadata:
+                error = (
+                    f"Missing {key} on "
+                    f"https://discourse.ubuntu.com/t/{topic_id}. "
+                    "This parameter is required to render takeovers"
+                )
+                errors.append(error)
+
         if len(errors) > 0:
             raise MarkdownError((", ").join(errors))
 
@@ -586,6 +596,7 @@ class EngagePages(BaseParser):
         for errors
         """
         errors = []
+
         if "title" not in metadata:
             error = (
                 "Missing title on "
@@ -602,21 +613,15 @@ class EngagePages(BaseParser):
             )
             errors.append(error)
 
-        if "lang" not in metadata:
-            error = (
-                "Missing lang on "
-                f"https://discourse.ubuntu.com/t/{topic_id}. "
-                "This parameter is required to render takeovers"
-            )
-            errors.append(error)
+        for key in self.additional_metadata_validation:
 
-        if "class" not in metadata:
-            error = (
-                "Missing class on "
-                f"https://discourse.ubuntu.com/t/{topic_id}. "
-                f"This parameter is required to render takeovers"
-            )
-            errors.append(error)
+            if key not in metadata:
+                error = (
+                    f"Missing {key} on "
+                    f"https://discourse.ubuntu.com/t/{topic_id}. "
+                    "This parameter is required to render takeovers"
+                )
+                errors.append(error)
 
         if len(errors) > 0:
             raise MarkdownError((", ").join(errors))

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse",
-    version="5.0.1",
+    version="5.0.2",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url=(


### PR DESCRIPTION
## Done

Currently on cn.u.com (and probably on jp.u.com) engage pages, we are receiving loads of [false positive errors](https://sentry.is.canonical.com/canonical/cn-ubuntu-com/), these errors occur because u.com need this metadata, but cn.u.com don't need it (it's always the same language)

Therefore, an argument was added, so that u.com can pass additional optional metadata checks, instead of enforcing it in the module.

## QA

- Go to https://cn-ubuntu-com-637.demos.haus/takeovers
- Now check that we aren't getting more errors on [cn.u.com sentry](https://sentry.is.canonical.com/canonical/cn-ubuntu-com/). Or if you find it difficult to see, you can delete the existing engage pages sentry errors and visit https://ubuntu-com-11864.demos.haus/takeovers again.

If you've got time to compare, to see clearly what's going on, you can:
- Add the test sentry_dsn to your .env.local (if you don't know how to find it, let me know)
- pull [down the PR](https://github.com/canonical/cn.ubuntu.com/pull/637) 
- add the `additional_metadata_validation=["lang", "class"]` in line , visit /takeovers, and [check back sentry](https://sentry.is.canonical.com/canonical/cn-ubuntu-com/) and you'll see all the sentry errors that you would get otherwise on u.com. (these are the false positives on cn.u.com)