### PR TITLE
Improve error reporting

### DIFF
--- a/canonicalwebteam/discourse/models.py
+++ b/canonicalwebteam/discourse/models.py
@@ -64,7 +64,15 @@ class DiscourseAPI:
             data={"params": f'{{"topics":"{topics}"}}'},
         )
 
-        return response.json()["rows"]
+        result = response.json()
+
+        if "errors" in result and "rows" not in result:
+            raise DataExplorerError(
+                f'{result["errors"][0]} Have you set the right api_key?'
+            )
+
+        pages = result["rows"]
+        return pages
 
     def get_topics_category(self, category_id, page=0):
         response = self.session.get(

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse",
-    version="5.0.2",
+    version="5.0.3",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url=(


### PR DESCRIPTION
Fixes #139 

When a result with no rows and an error message is returned, raise an exception and add a hint, that the API key might be missing.