### PR TITLE
Generate toc based on heading anchor tags

### DIFF
--- a/canonicalwebteam/discourse/parsers/base_parser.py
+++ b/canonicalwebteam/discourse/parsers/base_parser.py
@@ -74,13 +74,11 @@ class BaseParser:
         soup = self._process_topic_soup(topic_soup)
         self._replace_lightbox(soup)
         sections = self._get_sections(soup)
-        toc = self._generate_toc(soup)
 
         return {
             "title": topic["title"],
             "body_html": str(soup),
             "sections": sections,
-            "toc": toc,
             "updated": humanize.naturaltime(
                 updated_datetime.replace(tzinfo=None)
             ),
@@ -459,40 +457,6 @@ class BaseParser:
             sections.append(section)
 
         return sections
-
-    def _generate_toc(self, soup):
-        range = "2-4"
-        toc = []
-        current_list = toc
-        level = 0
-        previous_level = 0
-        heading_count = 0
-        previous_tag = None
-
-
-        headings = soup.findAll(re.compile(f'^h[{range}]$'))
-
-        for heading in headings:
-            current_tag = re.findall("\d", heading.name)[0]
-            if previous_tag and previous_tag < current_tag:
-                current_list = []
-                level += 1
-            elif previous_tag and previous_tag > current_tag:
-                current_list = toc
-                level -= 1
-                heading_count = 0
-
-            current_list.append(({"level": level,
-            "heading_text": re.sub("\n", "", heading.text)}))
-
-            if previous_level <= level:
-                toc[heading_count - 1]["children"] = (current_list)
-            else:
-                heading_count += 1
-
-            previous_tag = current_tag
-
-        return toc
 
     def _get_section(self, soup, title_text):
         """

--- a/canonicalwebteam/discourse/parsers/base_parser.py
+++ b/canonicalwebteam/discourse/parsers/base_parser.py
@@ -74,11 +74,13 @@ class BaseParser:
         soup = self._process_topic_soup(topic_soup)
         self._replace_lightbox(soup)
         sections = self._get_sections(soup)
+        toc = self._generate_toc(soup)
 
         return {
             "title": topic["title"],
             "body_html": str(soup),
             "sections": sections,
+            "toc": toc,
             "updated": humanize.naturaltime(
                 updated_datetime.replace(tzinfo=None)
             ),
@@ -457,6 +459,40 @@ class BaseParser:
             sections.append(section)
 
         return sections
+
+    def _generate_toc(self, soup):
+        range = "2-4"
+        toc = []
+        current_list = toc
+        level = 0
+        previous_level = 0
+        heading_count = 0
+        previous_tag = None
+
+
+        headings = soup.findAll(re.compile(f'^h[{range}]$'))
+
+        for heading in headings:
+            current_tag = re.findall("\d", heading.name)[0]
+            if previous_tag and previous_tag < current_tag:
+                current_list = []
+                level += 1
+            elif previous_tag and previous_tag > current_tag:
+                current_list = toc
+                level -= 1
+                heading_count = 0
+
+            current_list.append(({"level": level,
+            "heading_text": re.sub("\n", "", heading.text)}))
+
+            if previous_level <= level:
+                toc[heading_count - 1]["children"] = (current_list)
+            else:
+                heading_count += 1
+
+            previous_tag = current_tag
+
+        return toc
 
     def _get_section(self, soup, title_text):
         """

--- a/canonicalwebteam/discourse/parsers/docs.py
+++ b/canonicalwebteam/discourse/parsers/docs.py
@@ -732,6 +732,7 @@ class DocParser(BaseParser):
                     {
                         "heading_level": current_tag,
                         "heading_text": re.sub("\n", "", heading.text),
+                        "heading_slug": heading.a["name"]
                     }
                 )
             )

--- a/canonicalwebteam/discourse/parsers/docs.py
+++ b/canonicalwebteam/discourse/parsers/docs.py
@@ -718,7 +718,7 @@ class DocParser(BaseParser):
         current_list = headings_map
         previous_tag = None
 
-        headings = soup.findAll(re.compile("^h[2-3]$"))
+        headings = soup.find_all(["h2","h3"])
 
         for heading in headings:
             current_tag = re.findall(r"\d", heading.name)[0]

--- a/canonicalwebteam/discourse/parsers/docs.py
+++ b/canonicalwebteam/discourse/parsers/docs.py
@@ -718,10 +718,10 @@ class DocParser(BaseParser):
         current_list = headings_map
         previous_tag = None
 
-        headings = soup.findAll(re.compile(f"^h[2-3]$"))
+        headings = soup.findAll(re.compile("^h[2-3]$"))
 
         for heading in headings:
-            current_tag = re.findall("\d", heading.name)[0]
+            current_tag = re.findall(r"\d", heading.name)[0]
             if previous_tag and previous_tag < current_tag:
                 current_list = []
             elif previous_tag and previous_tag > current_tag:

--- a/canonicalwebteam/discourse/parsers/docs.py
+++ b/canonicalwebteam/discourse/parsers/docs.py
@@ -727,19 +727,20 @@ class DocParser(BaseParser):
             elif previous_tag and previous_tag > current_tag:
                 current_list = headings_map
 
-            current_list.append(
-                (
-                    {
-                        "heading_level": current_tag,
-                        "heading_text": re.sub("\n", "", heading.text),
-                        "heading_slug": heading.a["name"]
-                    }
+            if heading.a and heading.a.has_attr("name"):
+                current_list.append(
+                    (
+                        {
+                            "heading_level": current_tag,
+                            "heading_text": re.sub("\n", "", heading.text),
+                            "heading_slug": heading.a["name"],
+                        }
+                    )
                 )
-            )
 
-            if previous_tag and previous_tag <= current_tag:
-                headings_map[-1]["children"] = current_list
+                if previous_tag and previous_tag <= current_tag:
+                    headings_map[-1]["children"] = current_list
 
-            previous_tag = current_tag
+                previous_tag = current_tag
 
         return headings_map

--- a/canonicalwebteam/discourse/parsers/docs.py
+++ b/canonicalwebteam/discourse/parsers/docs.py
@@ -120,11 +120,13 @@ class DocParser(BaseParser):
 
         self._replace_lightbox(soup)
         sections = self._get_sections(soup)
+        toc = self._generate_toc(soup)
 
         return {
             "title": topic["title"],
             "body_html": str(soup),
             "sections": sections,
+            "toc": toc,
             "updated": humanize.naturaltime(
                 updated_datetime.replace(tzinfo=None)
             ),

--- a/canonicalwebteam/discourse/parsers/docs.py
+++ b/canonicalwebteam/discourse/parsers/docs.py
@@ -718,7 +718,7 @@ class DocParser(BaseParser):
         current_list = headings_map
         previous_tag = None
 
-        headings = soup.find_all(["h2","h3"])
+        headings = soup.find_all(["h2", "h3"])
 
         for heading in headings:
             current_tag = re.findall(r"\d", heading.name)[0]

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse",
-    version="5.0.4",
+    version="5.1.4",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url=(


### PR DESCRIPTION
## Done

- Adds the `_generate_toc` method that get the headings from a discourse document and creates a toc object detailing the headings and there associated potion in the pages hierarchy.

## QA

- You can include this PR in place of canonicalwebteam.discourse in your requirements.txt and then run the project as normal.
- For testing purposes I have create a [test-topic](https://discourse.ubuntu.com/t/test-topic/33987) on discourse which can be reached through u.com with the extension `/core/docs/test-topic`
- Currently it does not support toggalable TOC or a headings range