### PR TITLE
Fix bug when all headings on same level

### DIFF
--- a/canonicalwebteam/discourse/parsers/docs.py
+++ b/canonicalwebteam/discourse/parsers/docs.py
@@ -738,7 +738,7 @@ class DocParser(BaseParser):
                     )
                 )
 
-                if previous_tag and previous_tag <= current_tag:
+                if previous_tag and previous_tag < current_tag:
                     headings_map[-1]["children"] = current_list
 
                 previous_tag = current_tag


### PR DESCRIPTION
## Done

Minor change to fix a bug where the entire headings_map object would become the child of itself