### PR TITLE
Don't parse more than we need to

### DIFF
--- a/canonicalwebteam/discourse/app.py
+++ b/canonicalwebteam/discourse/app.py
@@ -33,7 +33,7 @@ class Discourse:
             Show a list of all URLs in the URL map
             """
 
-            self.parser.parse()
+            self.parser.ensure_parsed()
 
             urls = []
 
@@ -52,7 +52,7 @@ class Discourse:
             Show a list of all URLs in the URL map
             """
 
-            self.parser.parse()
+            self.parser.ensure_parsed()
             pages = []
 
             for key, value in self.parser.url_map.items():
@@ -160,7 +160,7 @@ class Docs(Discourse):
             """
             docs_version = ""
             path = "/" + path
-            self.parser.parse()
+            self.parser.ensure_parsed()
 
             if path == "/":
                 document = self.parser.parse_topic(self.parser.index_topic)
@@ -239,7 +239,7 @@ class Tutorials(Discourse):
             """
 
             path = "/" + path
-            self.parser.parse()
+            self.parser.ensure_parsed()
 
             if path == "/":
                 document = self.parser.parse_topic(self.parser.index_topic)

--- a/canonicalwebteam/discourse/parsers/docs.py
+++ b/canonicalwebteam/discourse/parsers/docs.py
@@ -41,6 +41,17 @@ class DocParser(BaseParser):
 
         return super().__init__(api, index_topic_id, url_prefix)
 
+    def ensure_parsed(self) -> bool:
+        """
+        Ensure that we have parsed the cooked post into parts.
+
+        returns True if it's already parsed, or False if we needed to parse.
+        """
+        if self.index_topic is not None:
+            return True
+        self.parse()
+        return False
+
     def parse(self):
         """
         Get the index topic and split it into:

--- a/canonicalwebteam/discourse/parsers/tutorials.py
+++ b/canonicalwebteam/discourse/parsers/tutorials.py
@@ -16,6 +16,17 @@ class TutorialParser(BaseParser):
         self.errors = []
         return super().__init__(api, index_topic_id, url_prefix)
 
+    def ensure_parsed(self) -> bool:
+        """
+        Ensure that we have parsed the cooked post into parts.
+
+        returns True if it's already parsed, or False if we needed to parse.
+        """
+        if self.index_topic is not None:
+            return True
+        self.parse()
+        return False
+
     def parse(self):
         """
         Get the index topic and split it into:

--- a/setup.py
+++ b/setup.py
@@ -7,10 +7,7 @@ setup(
     version="5.3.0",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
-    url=(
-        "https://github.com/canonical-web-and-design/"
-        "canonicalwebteam.discourse"
-    ),
+    url="https://github.com/canonical/canonicalwebteam.discourse",
     description=(
         "Flask extension to integrate discourse content generated "
         "to docs to your website."

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse",
-    version="5.2.4",
+    version="5.3.0",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url=(

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -153,7 +153,7 @@ class TestEnsureParsed(unittest.TestCase):
         discourse.init_app(app)
         docs = Docs(self._mock_parser, "document.html")
         docs.init_app(app)
-        tutorials = Tutorials(self._mock_parser, "document.html")
+        tutorials = Tutorials(self._mock_parser, "tutorial.html")
         tutorials.init_app(app)
         self._client = app.test_client()
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 from canonicalwebteam.discourse.models import DiscourseAPI
 from canonicalwebteam.discourse.parsers.base_parser import BaseParser
 from canonicalwebteam.discourse.parsers.docs import DocParser
+from canonicalwebteam.discourse.parsers.tutorials import TutorialParser
 
 
 class TestBaseParser(unittest.TestCase):
@@ -95,3 +96,25 @@ class TestDocParser(unittest.TestCase):
             self.assertTrue(parsed_already_second)
             mock_parse.assert_not_called()
 
+
+class TestTutorialParser(unittest.TestCase):
+
+    def test_ensure_parsed(self):
+        """Ensure parsed will call parse if and only index_topic is None."""
+        discourse_api = DiscourseAPI('https://base.url', session=MagicMock())
+
+        parser = TutorialParser(
+            api=discourse_api,
+            index_topic_id=1,
+            url_prefix="/",
+        )
+        with patch.object(parser, "parse", autospec=True) as mock_parse:
+            self.assertIsNone(parser.index_topic)
+            parsed_already_first = parser.ensure_parsed()
+            self.assertFalse(parsed_already_first)
+            mock_parse.assert_called_once_with()
+            mock_parse.reset_mock()
+            parser.index_topic = object()
+            parsed_already_second = parser.ensure_parsed()
+            self.assertTrue(parsed_already_second)
+            mock_parse.assert_not_called()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -9,7 +9,7 @@ from canonicalwebteam.discourse.parsers.tutorials import TutorialParser
 
 class TestBaseParser(unittest.TestCase):
     def test_parser_username_link(self):
-        discourse_api = DiscourseAPI('https://base.url', session=MagicMock())
+        discourse_api = DiscourseAPI("https://base.url", session=MagicMock())
 
         parser = BaseParser(
             api=discourse_api,
@@ -45,7 +45,7 @@ class TestBaseParser(unittest.TestCase):
         )
 
     def test_emdash_in_slug(self):
-        discourse_api = DiscourseAPI('https://base.url', session=MagicMock())
+        discourse_api = DiscourseAPI("https://base.url", session=MagicMock())
 
         parser = BaseParser(
             api=discourse_api,
@@ -75,10 +75,9 @@ class TestBaseParser(unittest.TestCase):
 
 
 class TestDocParser(unittest.TestCase):
-
     def test_ensure_parsed(self):
         """Ensure parsed will call parse if and only index_topic is None."""
-        discourse_api = DiscourseAPI('https://base.url', session=MagicMock())
+        discourse_api = DiscourseAPI("https://base.url", session=MagicMock())
 
         parser = DocParser(
             api=discourse_api,
@@ -98,10 +97,9 @@ class TestDocParser(unittest.TestCase):
 
 
 class TestTutorialParser(unittest.TestCase):
-
     def test_ensure_parsed(self):
         """Ensure parsed will call parse if and only index_topic is None."""
-        discourse_api = DiscourseAPI('https://base.url', session=MagicMock())
+        discourse_api = DiscourseAPI("https://base.url", session=MagicMock())
 
         parser = TutorialParser(
             api=discourse_api,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,15 +1,17 @@
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
+
+from canonicalwebteam.discourse.models import DiscourseAPI
 from canonicalwebteam.discourse.parsers.base_parser import BaseParser
+from canonicalwebteam.discourse.parsers.docs import DocParser
 
 
-class TestParser(unittest.TestCase):
+class TestBaseParser(unittest.TestCase):
     def test_parser_username_link(self):
-        discourse_api_mock = MagicMock()
-        discourse_api_mock.base_url = "https://base.url"
+        discourse_api = DiscourseAPI('https://base.url', session=MagicMock())
 
         parser = BaseParser(
-            api=discourse_api_mock,
+            api=discourse_api,
             index_topic_id=1,
             url_prefix="/",
         )
@@ -42,11 +44,10 @@ class TestParser(unittest.TestCase):
         )
 
     def test_emdash_in_slug(self):
-        discourse_api_mock = MagicMock()
-        discourse_api_mock.base_url = "https://base.url"
+        discourse_api = DiscourseAPI('https://base.url', session=MagicMock())
 
         parser = BaseParser(
-            api=discourse_api_mock,
+            api=discourse_api,
             index_topic_id=1,
             url_prefix="/",
         )
@@ -70,3 +71,27 @@ class TestParser(unittest.TestCase):
         )
 
         self.assertEqual("/t/sample--text/1", parsed_topic["topic_path"])
+
+
+class TestDocParser(unittest.TestCase):
+
+    def test_ensure_parsed(self):
+        """Ensure parsed will call parse if and only index_topic is None."""
+        discourse_api = DiscourseAPI('https://base.url', session=MagicMock())
+
+        parser = DocParser(
+            api=discourse_api,
+            index_topic_id=1,
+            url_prefix="/",
+        )
+        with patch.object(parser, "parse", autospec=True) as mock_parse:
+            self.assertIsNone(parser.index_topic)
+            parsed_already_first = parser.ensure_parsed()
+            self.assertFalse(parsed_already_first)
+            mock_parse.assert_called_once_with()
+            mock_parse.reset_mock()
+            parser.index_topic = object()
+            parsed_already_second = parser.ensure_parsed()
+            self.assertTrue(parsed_already_second)
+            mock_parse.assert_not_called()
+


### PR DESCRIPTION
This PR adds `ensure_parsed` to `Docs` and `Tutorials` parsers so that callers can be sure that the metadata is parsed, but not unnecessarily force a re-fetch and parse of that Discourse post.

This aims to increase performance