### PR TITLE
Add tox + pytest support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
       run: pip3 install tox
 
     - name: Test Python
-      run: tox -e test
+      run: tox
 
   check-inclusive-naming:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,12 +27,10 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Install system dependencies
-      run: |
-        pip3 install --upgrade setuptools==65.7.0 pip
-        pip3 install flake8 black
+      run: pip3 install tox
 
     - name: Lint Python
-      run: python3 -m flake8 --extend-ignore=E203 canonicalwebteam tests setup.py && python3 -m black --line-length 79 --check canonicalwebteam tests setup.py
+      run: tox -e lint
 
   test-python:
     runs-on: ubuntu-latest
@@ -41,12 +39,10 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Install system dependencies
-      run: |
-        pip3 install --upgrade setuptools==65.7.0 pip
-        pip3 install wheel
+      run: pip3 install tox
 
     - name: Test Python
-      run: python3 setup.py test
+      run: tox -e test
 
   check-inclusive-naming:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ dist/
 .webcache/
 
 .venv/
+.tox/

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ dist/
 .eggs/
 .webcache/
 
+.venv/

--- a/README.md
+++ b/README.md
@@ -41,13 +41,15 @@ Once this is added you will need to add the file `document.html` to your templat
 
 For local development, it's best to test this module with one of our website projects like [ubuntu.com](https://github.com/canonical-web-and-design/ubuntu.com/). For more information, follow [this guide (internal only)](https://discourse.canonical.com/t/how-to-run-our-python-modules-for-local-development/308).
 
-### Running tests
+### Running tests, linting and formatting
 
 Tests can be run with [Tox](https://tox.wiki/en/latest/):
 
 ``` bash
 pip3 install tox  # Install tox
-tox               # Setup environment and run tests
+tox               # Run tests
+tox -e lint       # Check the format of Python code
+tox -e format     # Reformat the Python code
 ```
 
 ## Instructions for Engage pages extension

--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ Once this is added you will need to add the file `document.html` to your templat
 
 For local development, it's best to test this module with one of our website projects like [ubuntu.com](https://github.com/canonical-web-and-design/ubuntu.com/). For more information, follow [this guide (internal only)](https://discourse.canonical.com/t/how-to-run-our-python-modules-for-local-development/308).
 
+### Running tests
+
+Tests can be run with [Tox](https://tox.wiki/en/latest/):
+
+``` bash
+pip3 install tox  # Install tox
+tox               # Setup environment and run tests
+```
+
 ## Instructions for Engage pages extension
 
 Because you are viewing a protected topic, you must provide `api_key` and `api_username`. You also need an index topic id, which you can get from discourse.ubuntu.com. Your index topic must contain a metadata section. Visit the EngageParser for more information about the structure. You are encouraged to use an blueprint name that does not collide with existent blueprints. The templates must match the ones provided in the parameters indicated.

--- a/canonicalwebteam/discourse/parsers/base_parser.py
+++ b/canonicalwebteam/discourse/parsers/base_parser.py
@@ -482,7 +482,7 @@ class BaseParser:
 
         <p>Content</p>
         """
-        heading = soup.find(HEADER_REGEX, text=title_text)
+        heading = soup.find(HEADER_REGEX, string=title_text)
 
         if not heading:
             return None
@@ -504,7 +504,7 @@ class BaseParser:
         the heading defined in `break_on_title`,
         and return it as a BeautifulSoup object
         """
-        heading = soup.find(HEADER_REGEX, text=break_on_title)
+        heading = soup.find(HEADER_REGEX, string=break_on_title)
 
         if not heading:
             return soup

--- a/canonicalwebteam/discourse/parsers/base_parser.py
+++ b/canonicalwebteam/discourse/parsers/base_parser.py
@@ -1,8 +1,5 @@
 # Standard library
-<<<<<<< HEAD
 import copy
-=======
->>>>>>> 2c6a9a4 (Re-use notification template)
 from functools import cached_property
 import os
 import re

--- a/canonicalwebteam/discourse/parsers/base_parser.py
+++ b/canonicalwebteam/discourse/parsers/base_parser.py
@@ -1,5 +1,8 @@
 # Standard library
+<<<<<<< HEAD
 import copy
+=======
+>>>>>>> 2c6a9a4 (Re-use notification template)
 from functools import cached_property
 import os
 import re

--- a/canonicalwebteam/discourse/parsers/base_parser.py
+++ b/canonicalwebteam/discourse/parsers/base_parser.py
@@ -614,7 +614,8 @@ class BaseParser:
                 </div>
             </div>
         """
-        for note_string in soup.findAll(text=re.compile("ⓘ ")):
+
+        for note_string in soup.find_all(string=re.compile("ⓘ ")):
             first_paragraph = note_string.parent
             blockquote = first_paragraph.parent
             last_paragraph = blockquote.findChildren(recursive=False)[-1]
@@ -758,7 +759,7 @@ class BaseParser:
         > ...
         """
 
-        notes_to_editors_text = soup.find_all(text="NOTE TO EDITORS")
+        notes_to_editors_text = soup.find_all(string="NOTE TO EDITORS")
 
         for text in notes_to_editors_text:
             # If this section is of the expected HTML format,

--- a/canonicalwebteam/discourse/parsers/docs.py
+++ b/canonicalwebteam/discourse/parsers/docs.py
@@ -814,7 +814,7 @@ class DocParser(BaseParser):
             else:
                 return value
 
-        heading = index_soup.find(re.compile("^h[1-6]$"), text=section_name)
+        heading = index_soup.find(re.compile("^h[1-6]$"), string=section_name)
 
         if not heading:
             return None

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
         "humanize",
         "lxml",
         "python-dateutil",
+        "talisker",
         "validators",
     ],
     tests_require=[

--- a/setup.py
+++ b/setup.py
@@ -23,5 +23,5 @@ setup(
         "requests",
         "python-dateutil",
         "validators",
-    ]
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,8 @@ setup(
         "beautifulsoup4",
         "humanize",
         "lxml",
+        "requests",
         "python-dateutil",
-        "talisker",
         "validators",
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -23,9 +23,5 @@ setup(
         "python-dateutil",
         "talisker",
         "validators",
-    ],
-    tests_require=[
-        "vcrpy-unittest",
-        "httpretty",
-    ],
+    ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -21,3 +21,10 @@ deps =
 commands =
     flake8 --extend-ignore=E203 canonicalwebteam tests setup.py
     black --line-length 79 --check canonicalwebteam tests setup.py
+
+[testenv:format]
+description = Format Python
+deps =
+    black
+commands =
+    black --line-length 79 canonicalwebteam tests setup.py

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,4 @@
 [tox]
-env_list =
-    py310
 minversion = 4.4.8
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,25 @@
+[tox]
+env_list =
+    py310
+minversion = 4.4.8
+
+[testenv]
+description = run the tests with pytest
+package = wheel
+wheel_build_env = .pkg
+deps =
+    pytest>=6
+    httpretty
+    lxml
+    vcrpy-unittest
+commands =
+    pytest {tty:--color=yes} {posargs}
+
+[testenv:lint]
+description = Lint Python
+deps =
+    flake8
+    black
+commands =
+    flake8 --extend-ignore=E203 canonicalwebteam tests setup.py
+    black --line-length 79 --check canonicalwebteam tests setup.py


### PR DESCRIPTION
Add's a `tox.ini` file with `lint` and `test` targets, and updates GH workflows to use tox instead.

This also invokes the tests using pytest, which is much nicer to use than `python setup.py test`