### PR TITLE
Parsing speedups

### DIFF
--- a/canonicalwebteam/discourse/parsers/base_parser.py
+++ b/canonicalwebteam/discourse/parsers/base_parser.py
@@ -1,4 +1,5 @@
 # Standard library
+import copy
 from functools import cached_property
 import os
 import re
@@ -450,7 +451,7 @@ class BaseParser:
             section_soup = self._get_section(soup, heading.text)
 
             section["title"] = heading.text
-            section["content"] = str(section_soup)
+            section["content"] = str(section_soup).strip()
 
             heading_pieces = filter(
                 lambda s: s.isalnum() or s.isspace(), heading.text.lower()
@@ -484,19 +485,13 @@ class BaseParser:
             return None
 
         heading_tag = heading.name
-
-        section_html = "".join(map(str, heading.fetchNextSiblings()))
-        section_soup = BeautifulSoup(section_html, features="html.parser")
-
-        # If there's another heading of the same level
-        # get the content before it
-        next_heading = section_soup.find(heading_tag)
-        if next_heading:
-            section_elements = next_heading.fetchPreviousSiblings()
-            section_elements.reverse()
-            section_html = "".join(map(str, section_elements))
-            section_soup = BeautifulSoup(section_html, features="html.parser")
-
+        section_soup = BeautifulSoup()
+        for sibling in list(heading.next_siblings):
+            if sibling is None:
+                break
+            if sibling.name == heading_tag:
+                break
+            section_soup.append(copy.copy(sibling))
         return section_soup
 
     def _get_preamble(self, soup, break_on_title):

--- a/canonicalwebteam/discourse/parsers/base_parser.py
+++ b/canonicalwebteam/discourse/parsers/base_parser.py
@@ -71,7 +71,7 @@ class BaseParser:
         topic_path = f"/t/{topic['slug']}/{topic['id']}".replace("—", "--")
 
         topic_soup = BeautifulSoup(
-            topic["post_stream"]["posts"][0]["cooked"], features="html.parser"
+            topic["post_stream"]["posts"][0]["cooked"], features="lxml"
         )
 
         soup = self._process_topic_soup(topic_soup)
@@ -647,7 +647,7 @@ class BaseParser:
                     contents=notification_html,
                 )
                 blockquote.replace_with(
-                    BeautifulSoup(notification, features="html.parser")
+                    BeautifulSoup(notification, features="lxml")
                 )
 
         for warning in soup.findAll("img", title=":warning:"):
@@ -677,7 +677,7 @@ class BaseParser:
                 )
 
                 blockquote.replace_with(
-                    BeautifulSoup(notification, features="html.parser")
+                    BeautifulSoup(notification, features="lxml")
                 )
 
         return soup

--- a/canonicalwebteam/discourse/parsers/base_parser.py
+++ b/canonicalwebteam/discourse/parsers/base_parser.py
@@ -22,6 +22,8 @@ TOPIC_URL_MATCH = re.compile(
     r"(?:/t)?(?:/(?P<slug>[^/]+))?/(?P<topic_id>\d+)(?:/\d+)?"
 )
 
+HEADER_REGEX = re.compile("^h[1-6]$")
+
 
 class ParsingError(Exception):
     pass
@@ -476,8 +478,7 @@ class BaseParser:
 
         <p>Content</p>
         """
-
-        heading = soup.find(re.compile("^h[1-6]$"), text=title_text)
+        heading = soup.find(HEADER_REGEX, text=title_text)
 
         if not heading:
             return None
@@ -505,8 +506,7 @@ class BaseParser:
         the heading defined in `break_on_title`,
         and return it as a BeautifulSoup object
         """
-
-        heading = soup.find(re.compile("^h[1-6]$"), text=break_on_title)
+        heading = soup.find(HEADER_REGEX, text=break_on_title)
 
         if not heading:
             return soup

--- a/canonicalwebteam/discourse/parsers/base_parser.py
+++ b/canonicalwebteam/discourse/parsers/base_parser.py
@@ -505,12 +505,11 @@ class BaseParser:
 
         if not heading:
             return soup
-
-        preamble_elements = heading.fetchPreviousSiblings()
-        preamble_elements.reverse()
-        preamble_html = "".join(map(str, preamble_elements))
-
-        return BeautifulSoup(preamble_html, features="html.parser")
+        # get all the previous contents, reversing order on insert
+        preamble_soup = BeautifulSoup()
+        for sibling in list(heading.previous_siblings):
+            preamble_soup.insert(0, sibling)
+        return preamble_soup
 
     def _process_topic_soup(self, soup):
         """

--- a/canonicalwebteam/discourse/parsers/docs.py
+++ b/canonicalwebteam/discourse/parsers/docs.py
@@ -474,9 +474,14 @@ class DocParser(BaseParser):
         tables = navigation_soup.findAll("table")
 
         for table in tables:
-            if table.select("tr:has(> th:-soup-contains('Version'))"):
-                version_table = table.select("tr:has(td)")
-
+            first_row = table.tr
+            if not first_row:
+                continue
+            headers = first_row("th")
+            if not headers:
+                continue
+            if headers[-1].string == "Version":
+                version_table = table("tr")[1:]
         # Parse version table or return a default one if it's missing
         if version_table:
             versions = []

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse",
-    version="5.3.0",
+    version="5.4.0",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical/canonicalwebteam.discourse",

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
         "Flask>=1.0.2",
         "beautifulsoup4",
         "humanize",
+        "lxml",
         "python-dateutil",
         "validators",
     ],

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -69,6 +69,7 @@ EXAMPLE_CONTENT = """
 </details>
 """
 
+
 class TestBaseParser(unittest.TestCase):
     def test_parser_username_link(self):
         discourse_api = DiscourseAPI("https://base.url", session=MagicMock())
@@ -180,7 +181,6 @@ class TestTutorialParser(unittest.TestCase):
             mock_parse.assert_not_called()
 
 
-
 class TestDocParser(unittest.TestCase):
     def setUp(self):
         # Suppress annoying warnings from HTTPretty
@@ -255,7 +255,9 @@ class TestDocParser(unittest.TestCase):
         self.assertEqual(len(section("table")), 1)
         self.assertEqual(len(section.table("tr")), 3)
         last_entry = section.table("tr")[-1]
-        self.assertEqual(list(last_entry.stripped_strings), ["1", "/page-z", "Page Z"])
+        self.assertEqual(
+            list(last_entry.stripped_strings), ["1", "/page-z", "Page Z"]
+        )
 
     def test_get_sections(self):
         soup = BeautifulSoup(

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -249,7 +249,7 @@ class TestDocParser(unittest.TestCase):
     def test_get_section(self):
         soup = BeautifulSoup(
             self.parser.index_topic["post_stream"]["posts"][0]["cooked"],
-            features="html.parser",
+            features="lxml",
         )
         section = self.parser._get_section(soup, "Navigation")
         self.assertEqual(len(section("table")), 1)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -262,6 +262,7 @@ class TestDocParser(unittest.TestCase):
             self.parser.index_topic["post_stream"]["posts"][0]["cooked"],
             features="lxml",
         )
+        soup_str = str(soup)
         sections = self.parser._get_sections(soup)
         self.assertEqual(len(sections), 2)
         first = sections[0]
@@ -278,6 +279,7 @@ class TestDocParser(unittest.TestCase):
         self.assertEqual(second["content"][:9], "<details>")
         self.assertEqual(second["content"][-10:], "</details>")
         self.assertEqual(len(second["content"]), 286)
+        self.assertEqual(str(soup), soup_str)
 
     def test_nav(self):
         navigation = self.parser.navigation

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -257,6 +257,28 @@ class TestDocParser(unittest.TestCase):
         last_entry = section.table("tr")[-1]
         self.assertEqual(list(last_entry.stripped_strings), ["1", "/page-z", "Page Z"])
 
+    def test_get_sections(self):
+        soup = BeautifulSoup(
+            self.parser.index_topic["post_stream"]["posts"][0]["cooked"],
+            features="lxml",
+        )
+        sections = self.parser._get_sections(soup)
+        self.assertEqual(len(sections), 2)
+        first = sections[0]
+        self.assertEqual(first.keys(), {"title", "content", "slug"})
+        self.assertEqual(first["title"], "Navigation")
+        self.assertEqual(first["slug"], "navigation")
+        self.assertEqual(first["content"][:9], "<details>")
+        self.assertEqual(first["content"][-10:], "</details>")
+        self.assertEqual(len(first["content"]), 353)
+        second = sections[1]
+        self.assertEqual(second.keys(), {"title", "content", "slug"})
+        self.assertEqual(second["title"], "Redirects")
+        self.assertEqual(second["slug"], "redirects")
+        self.assertEqual(second["content"][:9], "<details>")
+        self.assertEqual(second["content"][-10:], "</details>")
+        self.assertEqual(len(second["content"]), 286)
+
     def test_nav(self):
         navigation = self.parser.navigation
         page_a = navigation["nav_items"][0]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,5 +1,11 @@
+import json
 import unittest
 from unittest.mock import MagicMock, patch
+import warnings
+
+from bs4 import BeautifulSoup
+import httpretty
+import requests
 
 from canonicalwebteam.discourse.models import DiscourseAPI
 from canonicalwebteam.discourse.parsers.base_parser import BaseParser
@@ -74,7 +80,7 @@ class TestBaseParser(unittest.TestCase):
         self.assertEqual("/t/sample--text/1", parsed_topic["topic_path"])
 
 
-class TestDocParser(unittest.TestCase):
+class TestDocParserEnsureParsed(unittest.TestCase):
     def test_ensure_parsed(self):
         """Ensure parsed will call parse if and only index_topic is None."""
         discourse_api = DiscourseAPI("https://base.url", session=MagicMock())
@@ -116,3 +122,162 @@ class TestTutorialParser(unittest.TestCase):
             parsed_already_second = parser.ensure_parsed()
             self.assertTrue(parsed_already_second)
             mock_parse.assert_not_called()
+
+
+EXAMPLE_CONTENT = """
+<p>Some homepage content</p>
+<h2>Navigation</h2>
+
+<details>
+  <summary>Navigation items</summary>
+  <div class="md-table">
+    <table>
+      <thead>
+        <tr>
+          <th>Level</th>
+          <th>Path</th>
+          <th>Navlink</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>0</td>
+          <td>/a</td>
+          <td><a href="/t/page-a/10">Page A</a></td>
+        </tr>
+        <tr>
+          <td>1</td>
+          <td>/page-z</td>
+          <td><a href="/t/page-z/26">Page Z</a></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</details>
+
+<h2>Redirects</h2>
+<details>
+  <summary>Mapping table</summary>
+  <div class="md-table">
+    <table>
+      <thead>
+        <tr>
+          <th>PATH</th>
+          <th>LOCATION</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>/redir-a</td>
+          <td>/a</td>
+        </tr>
+        <tr>
+          <td>/example/page</td>
+          <td>https://example.com/page</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</details>
+"""
+
+
+class TestDocParser(unittest.TestCase):
+    def setUp(self):
+        # Suppress annoying warnings from HTTPretty
+        # See: https://github.com/gabrielfalcao/HTTPretty/issues/368
+        warnings.filterwarnings(
+            "ignore", category=ResourceWarning, message="unclosed.*"
+        )
+
+        # Enable HTTPretty and set up mock URLs
+        httpretty.enable()
+        self.addCleanup(httpretty.disable)
+        self.addCleanup(httpretty.reset)
+        # Index page with navigation, URL map and redirects
+        httpretty.register_uri(
+            httpretty.GET,
+            "https://discourse.example.com/t/34.json",
+            body=json.dumps(
+                {
+                    "id": 34,
+                    "category_id": 2,
+                    "title": "An index page",
+                    "slug": "an-index-page",
+                    "post_stream": {
+                        "posts": [
+                            {
+                                "id": 3434,
+                                "cooked": EXAMPLE_CONTENT,
+                                "updated_at": "2018-10-02T12:45:44.259Z",
+                            }
+                        ]
+                    },
+                }
+            ),
+            content_type="application/json",
+        )
+
+        discourse_api = DiscourseAPI(
+            base_url="https://discourse.example.com/",
+            session=requests.Session(),
+        )
+
+        self.parser = DocParser(
+            api=discourse_api,
+            index_topic_id=34,
+            url_prefix="/",
+        )
+        self.parser.parse()
+
+    def test_index_has_no_nav(self):
+        index_topic = self.parser.index_topic
+        index = self.parser.parse_topic(index_topic)
+        soup = BeautifulSoup(index["body_html"], features="lxml")
+
+        # Check body
+        self.assertEqual(soup.p.string, "Some homepage content")
+
+        # Check navigation
+        self.assertIsNone(soup.h1)
+
+        # Check URL map worked
+        self.assertIsNone(soup.details)
+        self.assertNotIn(
+            '<a href="/t/page-a/10">Page A</a>',
+            soup.decode_contents(),
+        )
+
+    def test_nav(self):
+        index_topic = self.parser.index_topic
+        self.parser.parse_topic(index_topic)
+        navigation = self.parser.navigation
+        page_a = navigation["nav_items"][0]
+        self.assertEqual(page_a["path"], "/a")
+        self.assertEqual(page_a["navlink_text"], "Page A")
+        page_z = page_a["children"][0]
+        self.assertEqual(page_z["path"], "/page-z")
+        self.assertEqual(page_z["navlink_text"], "Page Z")
+
+    def test_redirect_map(self):
+        self.assertEqual(
+            self.parser.redirect_map,
+            {"/redir-a": "/a", "/example/page": "https://example.com/page"},
+        )
+
+        self.assertEqual(self.parser.warnings, [])
+
+    def test_url_map(self):
+        self.assertEqual(
+            self.parser.url_map,
+            {
+                10: "/a",
+                26: "/page-z",
+                34: "/",
+                "/": 34,
+                "/a": 10,
+                "/page-z": 26,
+            },
+        )
+
+        self.assertEqual(self.parser.warnings, [])

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -12,6 +12,62 @@ from canonicalwebteam.discourse.parsers.base_parser import BaseParser
 from canonicalwebteam.discourse.parsers.docs import DocParser
 from canonicalwebteam.discourse.parsers.tutorials import TutorialParser
 
+EXAMPLE_CONTENT = """
+<p>Some homepage content</p>
+<h2>Navigation</h2>
+
+<details>
+  <summary>Navigation items</summary>
+  <div class="md-table">
+    <table>
+      <thead>
+        <tr>
+          <th>Level</th>
+          <th>Path</th>
+          <th>Navlink</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>0</td>
+          <td>/a</td>
+          <td><a href="/t/page-a/10">Page A</a></td>
+        </tr>
+        <tr>
+          <td>1</td>
+          <td>/page-z</td>
+          <td><a href="/t/page-z/26">Page Z</a></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</details>
+
+<h2>Redirects</h2>
+<details>
+  <summary>Mapping table</summary>
+  <div class="md-table">
+    <table>
+      <thead>
+        <tr>
+          <th>PATH</th>
+          <th>LOCATION</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>/redir-a</td>
+          <td>/a</td>
+        </tr>
+        <tr>
+          <td>/example/page</td>
+          <td>https://example.com/page</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</details>
+"""
 
 class TestBaseParser(unittest.TestCase):
     def test_parser_username_link(self):
@@ -82,7 +138,7 @@ class TestBaseParser(unittest.TestCase):
 
 class TestDocParserEnsureParsed(unittest.TestCase):
     def test_ensure_parsed(self):
-        """Ensure parsed will call parse if and only index_topic is None."""
+        """Ensure parsed will call parse if and only if index_topic is None."""
         discourse_api = DiscourseAPI("https://base.url", session=MagicMock())
 
         parser = DocParser(
@@ -104,7 +160,7 @@ class TestDocParserEnsureParsed(unittest.TestCase):
 
 class TestTutorialParser(unittest.TestCase):
     def test_ensure_parsed(self):
-        """Ensure parsed will call parse if and only index_topic is None."""
+        """Ensure parsed will call parse if and only if index_topic is None."""
         discourse_api = DiscourseAPI("https://base.url", session=MagicMock())
 
         parser = TutorialParser(
@@ -123,63 +179,6 @@ class TestTutorialParser(unittest.TestCase):
             self.assertTrue(parsed_already_second)
             mock_parse.assert_not_called()
 
-
-EXAMPLE_CONTENT = """
-<p>Some homepage content</p>
-<h2>Navigation</h2>
-
-<details>
-  <summary>Navigation items</summary>
-  <div class="md-table">
-    <table>
-      <thead>
-        <tr>
-          <th>Level</th>
-          <th>Path</th>
-          <th>Navlink</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>0</td>
-          <td>/a</td>
-          <td><a href="/t/page-a/10">Page A</a></td>
-        </tr>
-        <tr>
-          <td>1</td>
-          <td>/page-z</td>
-          <td><a href="/t/page-z/26">Page Z</a></td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-</details>
-
-<h2>Redirects</h2>
-<details>
-  <summary>Mapping table</summary>
-  <div class="md-table">
-    <table>
-      <thead>
-        <tr>
-          <th>PATH</th>
-          <th>LOCATION</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>/redir-a</td>
-          <td>/a</td>
-        </tr>
-        <tr>
-          <td>/example/page</td>
-          <td>https://example.com/page</td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-</details>
-"""
 
 
 class TestDocParser(unittest.TestCase):


### PR DESCRIPTION
This PR includes several commits that aim to remove slow paths when rendering docs.

Notably it seeks to minimise the number of times we parse HTML, (don't take a `BeautifulSoup`, carve it up, turn it back into a str, then make another `BeautifulSoup`).

It adds tests for the affected functions for extracting sections and allows one to easily drop in different `EXAMPLE_CONTENT` to run the tests with (where one might see times go from > 100s of milliseconds to ~11)

This addresses many of the problems that were [worked](https://github.com/canonical/maas.io/pulls?q=is%3Apr+speedups) [around](https://github.com/canonical/maas.io/pull/687) in maas.io docs which is now [one of the fastest sites we have](https://canonical.github.io/upptime/)