### PR TITLE
Don't mutate shared navigation model between requests

### DIFF
--- a/canonicalwebteam/discourse/parsers/docs.py
+++ b/canonicalwebteam/discourse/parsers/docs.py
@@ -1,4 +1,5 @@
 # Standard library
+import copy
 import os
 import re
 from urllib.parse import urlparse
@@ -31,7 +32,7 @@ class DocParser(BaseParser):
     ):
         self.active_topic_id = None
         self.versions = []
-        self.navigations = []
+        self.navigations = {}
         self.url_map_versions = {}
 
         # Tutorials
@@ -555,7 +556,10 @@ class DocParser(BaseParser):
         return False
 
     def _generate_navigation(self, navigations, version_path):
-        navigation = navigations[version_path]
+        # we mutate the navigations[version_path] dictionary and so to
+        # avoid retaining state between document views, we need to
+        # take a (deep)copy.
+        navigation = copy.deepcopy(navigations[version_path])
 
         # Replace links with url_map
         for item in navigation["nav_items"]:

--- a/canonicalwebteam/discourse/parsers/docs.py
+++ b/canonicalwebteam/discourse/parsers/docs.py
@@ -29,7 +29,7 @@ class DocParser(BaseParser):
         tutorials_index_topic_id=None,
         tutorials_url_prefix=None,
     ):
-        self.active_topic = None
+        self.active_topic_id = None
         self.versions = []
         self.navigations = []
         self.url_map_versions = {}
@@ -99,7 +99,7 @@ class DocParser(BaseParser):
                     (e.g. "3 days ago")
         - forum_link: The link to the original forum post
         """
-        self.active_topic = topic
+        self.active_topic_id = topic["id"]
 
         updated_datetime = dateutil.parser.parse(
             topic["post_stream"]["posts"][0]["updated_at"]
@@ -570,7 +570,7 @@ class DocParser(BaseParser):
                         item["navlink_href"] = href
 
                 # Check if given item should be marked as active
-                if topic_id == self.active_topic["id"]:
+                if topic_id == self.active_topic_id:
                     item["is_active"] = True
 
         # Generate tree structure with levels

--- a/canonicalwebteam/discourse/parsers/docs.py
+++ b/canonicalwebteam/discourse/parsers/docs.py
@@ -272,7 +272,9 @@ class DocParser(BaseParser):
                     pretty_path = url_prefix + pretty_path
 
                 if not topic_match or not pretty_path.startswith(url_prefix):
-                    self.warnings.append("Could not parse URL map item {item}")
+                    self.warnings.append(
+                        f"Could not parse URL map item {item}"
+                    )
                     continue
 
                 topic_id = int(topic_match.groupdict()["topic_id"])

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse",
-    version="5.4.0",
+    version="5.4.1",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical/canonicalwebteam.discourse",


### PR DESCRIPTION
Fixes #160 by operating on a copy of the version specific navigation set when decorating with `is_active` and `has_active_child`.

Drive-by fixes for just storing `active_topic_id` and not the whole topic, and fix to an f-string that was missing an f