### PR TITLE
Fix indefinite caching of index content by undoing "ensure_parsed" work

### DIFF
--- a/canonicalwebteam/discourse/app.py
+++ b/canonicalwebteam/discourse/app.py
@@ -33,7 +33,7 @@ class Discourse:
             Show a list of all URLs in the URL map
             """
 
-            self.parser.ensure_parsed()
+            self.parser.parse()
 
             urls = []
 
@@ -52,7 +52,7 @@ class Discourse:
             Show a list of all URLs in the URL map
             """
 
-            self.parser.ensure_parsed()
+            self.parser.parse()
             pages = []
 
             for key, value in self.parser.url_map.items():
@@ -160,7 +160,7 @@ class Docs(Discourse):
             """
             docs_version = ""
             path = "/" + path
-            self.parser.ensure_parsed()
+            self.parser.parse()
 
             if path == "/":
                 document = self.parser.parse_topic(self.parser.index_topic)
@@ -239,7 +239,7 @@ class Tutorials(Discourse):
             """
 
             path = "/" + path
-            self.parser.ensure_parsed()
+            self.parser.parse()
 
             if path == "/":
                 document = self.parser.parse_topic(self.parser.index_topic)

--- a/canonicalwebteam/discourse/parsers/docs.py
+++ b/canonicalwebteam/discourse/parsers/docs.py
@@ -42,17 +42,6 @@ class DocParser(BaseParser):
 
         return super().__init__(api, index_topic_id, url_prefix)
 
-    def ensure_parsed(self) -> bool:
-        """
-        Ensure that we have parsed the cooked post into parts.
-
-        returns True if it's already parsed, or False if we needed to parse.
-        """
-        if self.index_topic is not None:
-            return True
-        self.parse()
-        return False
-
     def parse(self):
         """
         Get the index topic and split it into:

--- a/canonicalwebteam/discourse/parsers/tutorials.py
+++ b/canonicalwebteam/discourse/parsers/tutorials.py
@@ -16,17 +16,6 @@ class TutorialParser(BaseParser):
         self.errors = []
         return super().__init__(api, index_topic_id, url_prefix)
 
-    def ensure_parsed(self) -> bool:
-        """
-        Ensure that we have parsed the cooked post into parts.
-
-        returns True if it's already parsed, or False if we needed to parse.
-        """
-        if self.index_topic is not None:
-            return True
-        self.parse()
-        return False
-
     def parse(self):
         """
         Get the index topic and split it into:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse",
-    version="5.4.1",
+    version="5.4.2",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical/canonicalwebteam.discourse",

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,6 +1,6 @@
 import json
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 import warnings
 
 from bs4 import BeautifulSoup
@@ -10,7 +10,6 @@ import requests
 from canonicalwebteam.discourse.models import DiscourseAPI
 from canonicalwebteam.discourse.parsers.base_parser import BaseParser
 from canonicalwebteam.discourse.parsers.docs import DocParser
-from canonicalwebteam.discourse.parsers.tutorials import TutorialParser
 
 EXAMPLE_CONTENT = """
 <p>Some homepage content</p>
@@ -135,50 +134,6 @@ class TestBaseParser(unittest.TestCase):
         )
 
         self.assertEqual("/t/sample--text/1", parsed_topic["topic_path"])
-
-
-class TestDocParserEnsureParsed(unittest.TestCase):
-    def test_ensure_parsed(self):
-        """Ensure parsed will call parse if and only if index_topic is None."""
-        discourse_api = DiscourseAPI("https://base.url", session=MagicMock())
-
-        parser = DocParser(
-            api=discourse_api,
-            index_topic_id=1,
-            url_prefix="/",
-        )
-        with patch.object(parser, "parse", autospec=True) as mock_parse:
-            self.assertIsNone(parser.index_topic)
-            parsed_already_first = parser.ensure_parsed()
-            self.assertFalse(parsed_already_first)
-            mock_parse.assert_called_once_with()
-            mock_parse.reset_mock()
-            parser.index_topic = object()
-            parsed_already_second = parser.ensure_parsed()
-            self.assertTrue(parsed_already_second)
-            mock_parse.assert_not_called()
-
-
-class TestTutorialParser(unittest.TestCase):
-    def test_ensure_parsed(self):
-        """Ensure parsed will call parse if and only if index_topic is None."""
-        discourse_api = DiscourseAPI("https://base.url", session=MagicMock())
-
-        parser = TutorialParser(
-            api=discourse_api,
-            index_topic_id=1,
-            url_prefix="/",
-        )
-        with patch.object(parser, "parse", autospec=True) as mock_parse:
-            self.assertIsNone(parser.index_topic)
-            parsed_already_first = parser.ensure_parsed()
-            self.assertFalse(parsed_already_first)
-            mock_parse.assert_called_once_with()
-            mock_parse.reset_mock()
-            parser.index_topic = object()
-            parsed_already_second = parser.ensure_parsed()
-            self.assertTrue(parsed_already_second)
-            mock_parse.assert_not_called()
 
 
 class TestDocParser(unittest.TestCase):


### PR DESCRIPTION
This undoes the work done in [PR 156][1], commits [2fc9e17][2], [b7d859][3] and [965aa6][4].

That work was attempting to avoid parsing through the index topic content more often than necessary,
by simply skipping the fetching of that content entirely once it's been downloaded once.

This caused [big problems][5] because no changes to any of the documentation index content, including
navigation updates, would be reflected until the application is re-released.

There may be more sensible ways to avoid parsing the index topic content too many times,
but for now this work needs to be rolled back.

Fixes https://github.com/canonical/canonicalwebteam.discourse/issues/163

## QA

Go to https://juju-is-472.demos.haus/docs. Then change something in [the index topic](https://discourse.charmhub.io/t/juju-documentation/4513) and go back and reload the docs page, see that the change is reflected (i.e. not cached). Don't forget to change the index topic back again.

[1]: https://github.com/canonical/canonicalwebteam.discourse/pull/156
[2]: https://github.com/canonical/canonicalwebteam.discourse/pull/156/commits/2fc9e173404c93b19cbe22c7d1e6b002000b47cb
[3]: https://github.com/canonical/canonicalwebteam.discourse/pull/156/commits/b7d859f1d9fb7b93bb46333ce4396987328d2af4
[4]: https://github.com/canonical/canonicalwebteam.discourse/pull/156/commits/965aa68b87ba7c748d2835f86b9a3b99772e2e5d
[5]: https://github.com/canonical/canonicalwebteam.discourse/issues/163
