### PR TITLE
Check it a header contains a link

### DIFF
--- a/canonicalwebteam/discourse/parsers/base_parser.py
+++ b/canonicalwebteam/discourse/parsers/base_parser.py
@@ -479,7 +479,11 @@ class BaseParser:
         <p>Content</p>
         """
         for heading in soup(HEADER_REGEX):
-            if heading.string is None and heading.a.next == title_text:
+            if (
+                heading.string is None
+                and heading.a
+                and heading.a.next == title_text
+            ):
                 break
             elif heading.string == title_text:
                 break
@@ -504,7 +508,11 @@ class BaseParser:
         and return it as a BeautifulSoup object
         """
         for heading in soup(HEADER_REGEX):
-            if heading.string is None and heading.a.next == break_on_title:
+            if (
+                heading.string is None
+                and heading.a
+                and heading.a.next == break_on_title
+            ):
                 break
             elif heading.string == break_on_title:
                 break


### PR DESCRIPTION
## Done

Improved the null checking on the next link

## QA

- Go to https://ubuntu.com/landscape/docs/quickstart-deployment and see it errors
- Locally change `requirements.txt` of ubuntu.com project to: 
```
# canonicalwebteam.discourse==5.4.3
canonicalwebteam.discourse @ git+https://github.com/anthonydillon/canonicalwebteam.discourse@check-header-has-link`
```
- Run `dotrun clean && dotrun`
- Go to http://0.0.0.0:8001/landscape/docs/quickstart-deployment
- See that the page loads
- Check a few pages all load correctly