### PR TITLE
Strip heading titles

### DIFF
--- a/canonicalwebteam/discourse/parsers/base_parser.py
+++ b/canonicalwebteam/discourse/parsers/base_parser.py
@@ -447,13 +447,13 @@ class BaseParser:
 
         for heading in headings:
             section = {}
-            section_soup = self._get_section(soup, heading.text)
-
-            section["title"] = heading.text
+            heading_text = heading.text.strip()
+            section_soup = self._get_section(soup, heading_text)
+            section["title"] = heading_text
             section["content"] = str(section_soup).strip()
 
             heading_pieces = filter(
-                lambda s: s.isalnum() or s.isspace(), heading.text.lower()
+                lambda s: s.isalnum() or s.isspace(), heading_text.lower()
             )
             section["slug"] = "".join(heading_pieces).replace(" ", "-")
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse",
-    version="5.4.3",
+    version="5.4.4",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical/canonicalwebteam.discourse",


### PR DESCRIPTION
## Done
Strip white spaces from heading title. In newer versions of discourse the headings titles in cooked html are prefixed with new lines and it breaks the section parsing.

## QA

In a few different projects that use discourse(ubuntu.com, maas.io, charmhub.io):

```
# canonicalwebteam.discourse==5.4.4
canonicalwebteam.discourse @ git+https://github.com/canonical/canonicalwebteam.discourse@heading-title-strip
```
- Run `dotrun clean && dotrun`
- Go to http://0.0.0.0:8001/landscape/docs/quickstart-deployment
- See that the page loads
- Check a few pages all load correctly