### PR TITLE
Fix rate limit error exception

### DIFF
--- a/canonicalwebteam/discourse/models.py
+++ b/canonicalwebteam/discourse/models.py
@@ -110,8 +110,8 @@ class DiscourseAPI:
 
         result = response.json()
 
-        if not result["success"]:
-            raise DataExplorerError(response["errors"][0])
+        if "errors" in result:
+            raise DataExplorerError(result["errors"][0])
 
         pages = result["rows"]
         return pages
@@ -166,8 +166,8 @@ class DiscourseAPI:
         response.raise_for_status()
         result = response.json()
 
-        if not result["success"]:
-            raise DataExplorerError(response["errors"][0])
+        if "errors" in result:
+            raise DataExplorerError(result["errors"][0])
 
         pages = result["rows"]
         return pages

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse",
-    version="5.4.5",
+    version="5.4.6",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical/canonicalwebteam.discourse",


### PR DESCRIPTION
The response seems to have changed, there is no more "success" property in the `response.json` when there is an error.

## QA

- Go to your local ubuntu.com project folder
- Add `canonicalwebteam.discourse @ git+https://github.com/carkod/canonicalwebteam.discourse@discourse` to the `requirements.txt`
- Comment out `canonicalwebteam.discourse` currently in `requirements.txt`
`dotrun clean && dotrun`
- Go to /engage, refresh several times until you hit the rate limit error, you should have now a properly formatted Exception instead of `success not in result`