### PR TITLE
Strip heading titles for tutorials

### DIFF
--- a/canonicalwebteam/discourse/parsers/tutorials.py
+++ b/canonicalwebteam/discourse/parsers/tutorials.py
@@ -54,7 +54,8 @@ class TutorialParser(BaseParser):
 
         for heading in headings:
             section = {}
-            section_soup = self._get_section(soup, heading.text)
+            heading_text = heading.text.strip()
+            section_soup = self._get_section(soup, heading_text)
             first_child = section_soup.find() if section_soup else None
 
             if first_child and first_child.text.startswith("Duration"):
@@ -72,11 +73,11 @@ class TutorialParser(BaseParser):
 
                 first_child.extract()
 
-            section["title"] = heading.text
+            section["title"] = heading_text
             section["content"] = str(section_soup)
 
             heading_pieces = filter(
-                lambda s: s.isalnum() or s.isspace(), heading.text.lower()
+                lambda s: s.isalnum() or s.isspace(), heading_text.lower()
             )
             section["slug"] = "".join(heading_pieces).replace(" ", "-")
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse",
-    version="5.4.4",
+    version="5.4.5",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical/canonicalwebteam.discourse",


### PR DESCRIPTION
## Done
Strip white spaces from heading title. In newer versions of discourse the headings titles in cooked html are prefixed with new lines and it breaks the section parsing.
Bumped version

## QA

In your local ubuntu.com project do the following in the requirements.txt

```
# canonicalwebteam.discourse==5.4.4
canonicalwebteam.discourse @ git+https://github.com/anthonydillon/canonicalwebteam.discourse@strip-headings-tutorials
```
- Run `dotrun clean && dotrun`
- Go to http://localhost:8001/tutorials/install-ubuntu-desktop#1-overview
- See that the page loads
- Check a few pages all load correctly