### PR TITLE
Handle images in links

### DIFF
--- a/canonicalwebteam/discourse/parsers/base_parser.py
+++ b/canonicalwebteam/discourse/parsers/base_parser.py
@@ -565,7 +565,12 @@ class BaseParser:
                 continue
 
             # For user references link to discourse profile pages
-            if full_link and full_link.startswith("/u/") and a.string and a.string.startswith("@"):
+            if (
+                full_link
+                and full_link.startswith("/u/")
+                and a.string
+                and a.string.startswith("@")
+            ):
                 a["href"] = os.path.join(
                     self.api.base_url, full_link.lstrip("/")
                 )
@@ -599,7 +604,6 @@ class BaseParser:
                     a["href"] = urlunparse(url_parts)
 
         return soup
-
 
     def _replace_image_src(self, soup):
         """

--- a/canonicalwebteam/discourse/parsers/base_parser.py
+++ b/canonicalwebteam/discourse/parsers/base_parser.py
@@ -531,6 +531,7 @@ class BaseParser:
 
         soup = self._replace_notifications(soup)
         soup = self._replace_notes_to_editors(soup)
+        soup = self._replace_image_src(soup)
         soup = self._replace_links(soup)
         soup = self._replace_polls(soup)
 
@@ -556,8 +557,15 @@ class BaseParser:
             full_link = a.get("href", "")
             self._replace_text_link(a, topics)
 
+            # For images, link to the uploaded file
+            if a.find("img") and full_link.startswith("/uploads/"):
+                a["href"] = os.path.join(
+                    self.api.base_url, full_link.lstrip("/")
+                )
+                continue
+
             # For user references link to discourse profile pages
-            if full_link.startswith("/u") and a.string.startswith("@"):
+            if full_link and full_link.startswith("/u/") and a.string and a.string.startswith("@"):
                 a["href"] = os.path.join(
                     self.api.base_url, full_link.lstrip("/")
                 )
@@ -589,6 +597,20 @@ class BaseParser:
                         url_parts = url_parts._replace(path=absolute_link)
 
                     a["href"] = urlunparse(url_parts)
+
+        return soup
+
+
+    def _replace_image_src(self, soup):
+        """
+        Given some HTML soup, replace relative image srcs
+        """
+        for img in soup.findAll("img"):
+            src = img.get("src", "")
+            if src and src.startswith("/"):
+                img["src"] = f"{self.api.base_url}{src}"
+            if img["srcset"]:
+                del img["srcset"]
 
         return soup
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse",
-    version="5.4.5",
+    version="5.4.6",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical/canonicalwebteam.discourse",

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -126,7 +126,9 @@ class TestBaseParser(unittest.TestCase):
                         {
                             "id": 11,
                             "cooked": (
-                                "<a href='/uploads/test.png'><img src='test.png' srcset='test.png' /></a>"
+                                "<a href='/uploads/test.png'>"
+                                "<img src='test.png' srcset='test.png' />"
+                                "</a>"
                                 "<a>No Link</a>"
                                 "<a></a>"
                             ),
@@ -138,7 +140,11 @@ class TestBaseParser(unittest.TestCase):
         )
 
         self.assertIn(
-            '<a href="https://base.url/uploads/test.png"><img src="test.png"/></a>',
+            (
+                '<a href="https://base.url/uploads/test.png">'
+                '<img src="test.png"/>'
+                "</a>"
+            ),
             parsed_topic["body_html"],
         )
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -106,6 +106,42 @@ class TestBaseParser(unittest.TestCase):
             parsed_topic["body_html"],
         )
 
+    def test_parser_upload(self):
+        discourse_api = DiscourseAPI("https://base.url", session=MagicMock())
+
+        parser = BaseParser(
+            api=discourse_api,
+            index_topic_id=1,
+            url_prefix="/",
+        )
+
+        parsed_topic = parser.parse_topic(
+            {
+                "id": 1,
+                "category_id": 1,
+                "title": "Sample",
+                "slug": "sample—text",
+                "post_stream": {
+                    "posts": [
+                        {
+                            "id": 11,
+                            "cooked": (
+                                "<a href='/uploads/test.png'><img src='test.png' srcset='test.png' /></a>"
+                                "<a>No Link</a>"
+                                "<a></a>"
+                            ),
+                            "updated_at": "2018-10-02T12:45:44.259Z",
+                        }
+                    ],
+                },
+            }
+        )
+
+        self.assertIn(
+            '<a href="https://base.url/uploads/test.png"><img src="test.png"/></a>',
+            parsed_topic["body_html"],
+        )
+
     def test_emdash_in_slug(self):
         discourse_api = DiscourseAPI("https://base.url", session=MagicMock())
 


### PR DESCRIPTION
Handle images within a discourse topic - https://discourse.charmhub.io/t/observe-your-charm-with-cos-lite/7814 for example.

QA:
- Pull this branch
- Clone juju.is
- Update juju.is requirements.txt:
  ```
  #canonicalwebteam.discourse==5.4.4
  -e ./canonicalwebteam.discourse
  ```
- Within juju.is run `dotrun -m "/path/to/canonicalwebteam.discourse":"canonicalwebteam.discourse"` (you need the most up to date version of dotrun)
- Visit http://localhost:8041/docs/sdk/observe-your-charm-with-cos-lite and ensure the image at the bottom of the page loads and links to https://discourse.charmhub.io/uploads/default/optimized/2X/4/45cb7e9d3eb7c99cae62e615e3ff59663856e966_2_690x466.png
