### PR TITLE
Fix srcset lookup

### DIFF
--- a/canonicalwebteam/discourse/parsers/base_parser.py
+++ b/canonicalwebteam/discourse/parsers/base_parser.py
@@ -613,7 +613,7 @@ class BaseParser:
             src = img.get("src", "")
             if src and src.startswith("/"):
                 img["src"] = f"{self.api.base_url}{src}"
-            if img["srcset"]:
+            if img.get("srcset", None):
                 del img["srcset"]
 
         return soup

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse",
-    version="5.4.6",
+    version="5.4.7",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical/canonicalwebteam.discourse",

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -129,6 +129,9 @@ class TestBaseParser(unittest.TestCase):
                                 "<a href='/uploads/test.png'>"
                                 "<img src='test.png' srcset='test.png' />"
                                 "</a>"
+                                "<a href='/uploads/test2.png'>"
+                                "<img src='test2.png' />"
+                                "</a>"
                                 "<a>No Link</a>"
                                 "<a></a>"
                             ),
@@ -143,6 +146,14 @@ class TestBaseParser(unittest.TestCase):
             (
                 '<a href="https://base.url/uploads/test.png">'
                 '<img src="test.png"/>'
+                "</a>"
+            ),
+            parsed_topic["body_html"],
+        )
+        self.assertIn(
+            (
+                '<a href="https://base.url/uploads/test2.png">'
+                '<img src="test2.png"/>'
                 "</a>"
             ),
             parsed_topic["body_html"],


### PR DESCRIPTION
Handle images within a discourse topic - https://discourse.charmhub.io/t/endpoint/5462 for example - that don't have srcset.

QA:

Pull this branch
Clone juju.is
Update juju.is requirements.txt:
#canonicalwebteam.discourse==5.4.4
-e ./canonicalwebteam.discourse
Within juju.is run dotrun -m "/path/to/canonicalwebteam.discourse":"canonicalwebteam.discourse" (you need the most up to date version of dotrun)
Visit http://localhost:8041/docs/juju/endpoint and ensure the images at the bottom of the page load