### PR TITLE
Update examples and docs for new layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Flask extension to integrate discourse content generated to docs to your website
 
 Documentation for how to write documentation pages in Discourse for consumption by this module and how to configure the website to use the module can be found [in the Canonical discourse](https://discourse.canonical.com/t/creating-discourse-based-documentation-pages/159).
 
-Example Flask template for documentation pages can be found in [`examples/document.html`](https://github.com/canonical-web-and-design/canonicalwebteam.discourse/blob/main/examples/document.html)
+Example Flask template for documentation pages can be found in [`examples`](/examples/) folder. Please refer to the [README](/examples/README.md) in that folder for more information.
 
 ## Install
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,45 @@
+# Documentation layout for Discourse docs
+
+## Full-width documentation layout
+
+Vanilla 4.5.0 introduced a new full-width documentation layout. This layout is recommended for all new documentation sites.
+
+### Requirements
+
+To use new documentation layout you need to use Vanilla 4.5.0 or newer and Discourse 2.7.0 or newer (to have a support for automatically generated table of contents).
+
+### Layout
+
+Please familarise yourself with [the Vanilla documentation about the documentation layout](https://vanillaframework.io/docs/layouts/documentation) to have a better understanding of the structure.
+
+### Template for Discourse docs
+
+Example template for documentation pages can be found in [`examples/document.html`](document.html).
+
+This template needs to extend a base layout template of the project and replace the whole contents of the `<body>` element, because top navigation and footer need to be adjusted to new layout as well.
+
+It's recommended to have partial templates for header and footer and include them in the brochure layout template and in the documentation template. In our example the `is_docs`` template variable is used to differentiate between docs and other pages in partials so that they can render differently.
+
+#### Customisation
+
+There are several elements that can or need to be customised when applying the template to your project.
+
+- name of the base layout template that is being extended
+- contents of `{% block title %}` need to be adjusted
+- names and contents of partial templates for header and footer
+- adjust `expandable` parameter to `create_navigation` if expandable navigation is needed
+
+There may be other changes needed based on the project-specific needs.
+
+#### Example usage
+
+The new documentation layout is already used on [microk8s.io](https://microk8s.io/docs). You can refer to the pull request [canonical/mikrok8s.io#624](https://github.com/canonical/microk8s.io/pull/624/files) that introduced the new layout for an example of how to use it.
+
+## Old brochure site documentation layout
+
+For an example template of the old brochure site documentation layout, see [`examples/document-brochure.html`](document-brochure.html).
+
+Please note that the use of this old template is not recommended on new sites. Please use the official full-width documentation layout described above if possible.
+
+
+

--- a/examples/_footer.html
+++ b/examples/_footer.html
@@ -1,0 +1,63 @@
+{#
+    This is an example of footer partial to be used with documentation layout.
+    It extracts consists of 2 versions so they can be reused in standard brochure site layout
+    and documentation layout (based on the value of `is_docs` template variable).
+
+    See examples/README.md for more details.
+#}
+
+{% if is_docs %}
+<footer class="p-footer">
+  <div class="l-docs__subgrid">
+    <div class="l-docs__sidebar">
+      <div class="u-fixed-width">
+        <p>© {{ now("%Y") }} Canonical Ltd.</p>
+      </div>
+    </div>
+    <div class="l-docs__main">
+      <div class="row">
+        <div class="col-3 col-medium-2">
+          <ul class="p-list is-dark">
+            <li class="p-list__item--condensed">
+              <a href="https://www.ubuntu.com/legal">Legal information</a>
+            </li>
+            <li class="p-list__item--condensed">
+              <a href="" class="js-revoke-cookie-manager">Manage your tracker settings</a>
+            </li>
+            <li class="p-list__item--condensed">
+              <a class="p-footer__link" href="https://github.com/canonical/[YOUR REPO HERE]/issues/new">Report a bug on this site</a>
+            </li>
+          </ul>
+        </div>
+        <div class="col-9 col-medium-4">
+          <p>Ubuntu and Canonical are registered trademarks of Canonical&nbsp;Ltd.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</footer>
+{% else %}
+<footer class="p-footer l-footer--sticky">
+  <div class="row">
+    <div class="col-3 col-medium-2">
+      <p>© {{ now("%Y") }} Canonical Ltd.</p>
+    </div>
+    <div class="col-3 col-medium-2">
+      <ul class="p-list is-dark">
+        <li class="p-list__item--condensed">
+          <a href="https://www.ubuntu.com/legal">Legal information</a>
+        </li>
+        <li class="p-list__item--condensed">
+          <a href="" class="js-revoke-cookie-manager">Manage your tracker settings</a>
+        </li>
+        <li class="p-list__item--condensed">
+          <a class="p-footer__link" href="https://github.com/canonical/[YOUR REPO HERE]/issues/new">Report a bug on this site</a>
+        </li>
+      </ul>
+    </div>
+    <div class="col-6 col-medium-2">
+      <p>Ubuntu and Canonical are registered trademarks of Canonical&nbsp;Ltd.</p>
+    </div>
+  </div>
+</footer>
+{% endif %}

--- a/examples/_header.html
+++ b/examples/_header.html
@@ -1,0 +1,59 @@
+{#
+    This is an example of top navigation header partial to be used with documentation layout.
+    It extracts common navigation elements (logo and navigation items) into macros,
+    so they can be reused in standard brochure site layout and documentation layout
+    (based on the value of `is_docs` template variable).
+
+    See examples/README.md for more details.
+#}
+
+{% macro nav_logo() %}
+<div class="p-navigation__banner {% if not is_docs %}u-no-padding--left{% endif %}">
+  <div class="p-navigation__tagged-logo">
+    <a class="p-navigation__link" href="/">
+      <div class="p-navigation__logo-tag">
+        <img class="p-navigation__logo-icon" src="https://assets.ubuntu.com/v1/82818827-CoF_white.svg" alt="Canonical" width="95">
+      </div>
+      <span class="p-navigation__logo-title">Canonical</span>
+    </a>
+  </div>
+  <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
+  <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
+</div>
+{% endmacro %}
+
+{% macro nav_items() %}
+<nav class="p-navigation__nav" aria-label="main-navigation">
+  <ul class="p-navigation__items">
+    <li class="p-navigation__item {% if request.path in ['/docs',] %}is-selected{% endif %}">
+      <a href="/docs" class="p-navigation__link">Docs</a>
+    </li>
+    {#
+        FIXME: Put your navigation items here
+    #}
+  </ul>
+  <ul class="p-navigation__items global-nav"></ul>
+</nav>
+{% endmacro %}
+
+<a href="#main-content" class="p-link--skip">Jump to main content</a>
+
+<header id="navigation" class="p-navigation is-dark">
+  {% if is_docs %}
+  <div class="l-docs__subgrid">
+    <div class="l-docs__sidebar">
+      {{ nav_logo() }}
+    </div>
+    <div class="l-docs__main">
+      <div class="p-navigation__row u-fixed-width">
+        {{ nav_items() }}
+      </div>
+    </div>
+  </div>
+  {% else %}
+  <div class="p-navigation__row">
+      {{ nav_logo() }}
+      {{ nav_items() }}
+  </div>
+  {% endif %}
+</header>

--- a/examples/document-brochure.html
+++ b/examples/document-brochure.html
@@ -1,20 +1,7 @@
-{#
-  This is an example template for documentation pages using full width documentation layout.
-  Some details of it need to be edited to fit template and partial names in your project,
-  or any other custom project-specific updates.
+{% extends "_layouts/site.html" %}
 
-  See examples/README.md for more details on how to apply this template in your project.
-#}
-{% extends "base_layout.html" %}
+{% block title %}{{ document.title }}{% endblock %}
 
-{% block title %}[YOUR SITE TITLE HERE] - {{ document.title }} {% endblock %}
-
-{% set is_docs = True %}
-{% block body %}
-
-{#
-  This is a macro that generates side navigation
-#}
 {% macro create_navigation(nav_items, expandable=False, expanded=False) %}
   <ul class="p-side-navigation__list">
     {% for element in nav_items %}
@@ -23,8 +10,8 @@
       <a
         class="p-side-navigation__link {% if expandable and element.children %}is-expandable{% endif %}"
         href="{{ element.navlink_href }}"
-        {% if expandable and element.children %}aria-expanded={% if expanded or element.is_active %}"true"{% else %}"false"{% endif %}{% endif %}
-        {% if element.is_active and not element.navlink_fragment %}aria-current="page"{% endif %}
+        {% if expandable and element.children %}aria-expanded={% if expanded %}"true"{% else %}"false"{% endif %}{% endif %}
+        {% if element.is_active %}aria-current="page"{% endif %}
       >{{ element.navlink_text }}</a>
       {% else %}
         <strong
@@ -49,120 +36,58 @@
   </ul>
 {% endmacro %}
 
-<div class="l-docs">
-  {#
-    HEADER AREA
-    Contains top navigation and search box
-  #}
-  <div class="l-docs__header">
-    {% include "_header.html" %}
-    <section id="search-docs" class="p-strip is-shallow is-bordered l-docs__subgrid">
-      <div class="l-docs__main">
-        <div class="row">
-          <form class="p-search-box u-no-margin--bottom" action="/docs/search">
-            <input type="search" class="p-search-box__input" name="q" {% if query %}value="{{ query }}"{% endif %} placeholder="Search documentation" required/>
-            <button type="submit" class="p-search-box__button"><i class="p-icon--search">Search</i></button>
-          </form>
-        </div>
-      </div>
-    </section>
-  </div>
 
-  {#
-    SIDEBAR AREA
-    Contains side navigation
-  #}
-  <div class="l-docs__sidebar">
-    <div class="l-docs__sticky-container">
-      <nav data-js="navigation" class="p-side-navigation" id="{{ navigation['path'] or 'default' }}" style="margin-top: 0.5rem">
-        <div class="u-hide--large p-strip is-shallow">
-          <div class="u-fixed-width">
-            <a href="#{{ navigation['path'] or 'default' }}" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="{{ navigation['path'] or 'default' }}">
-              Toggle side navigation
-            </a>
-          </div>
-        </div>
-        <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="{{ navigation['path'] or 'default' }}"></div>
+{% block content %}
+<div class="p-strip is-shallow">
+  <div class="row">
+    <aside class="col-3">
+      {% if versions | length > 1 %}
+      <label for="version-select" class="u-hide">Version</label>
+      <select name="version-select" id="version-select" onChange="window.location.href=this.value">
+      {% for version in versions %}
+        {% set active = docs_version == version['path'] %}
+        <option value="{{ version_paths[version['path']] }}"{% if active %} selected{% endif %}>Version {{ version['version'] }}</option>
+      {% endfor %}
+      <select>
+      {% endif %}
+
+      <div class="p-side-navigation" id="drawer">
+        <a href="#drawer" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">
+          Toggle side navigation
+        </a>
+        <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="drawer"></div>
         <div class="p-side-navigation__drawer">
           <div class="p-side-navigation__drawer-header">
-            <a href="#" class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="{{ navigation['path'] or 'default' }}">
+            <a href="#" class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer">
               Toggle side navigation
             </a>
           </div>
           {% for nav_group in navigation.nav_items %}
-          {% if not nav_group.hidden %}
-            {% if nav_group.navlink_text %}
-              {% if nav_group.navlink_href %}
-              <h3 class="p-side-navigation__heading--linked">
-                <a class="p-side-navigation__link" href="{{ nav_group.navlink_href }}" {% if nav_group.is_active %}aria-current="page"{% endif %}>
-                  {{ nav_group.navlink_text }}
-                </a>
-              </h3>
-              {% else %}
-                <h3 class="p-side-navigation__heading">{{ nav_group.navlink_text }}</h3>
+            {% if not nav_group.hidden %}
+              {% if nav_group.navlink_text %}
+                {% if nav_group.navlink_href %}
+                <h3 class="p-side-navigation__heading--linked">
+                  <a class="p-side-navigation__link" href="{{ nav_group.navlink_href }}" {% if nav_group.is_active %}aria-current="page"{% endif %}>
+                    {{ nav_group.navlink_text }}
+                  </a>
+                </h3>
+                {% else %}
+                  <h3 class="p-side-navigation__heading">{{ nav_group.navlink_text }}</h3>
+                {% endif %}
               {% endif %}
+              {#
+                Use `create_navigation(nav_group.children)` for a default, fully expanded navigation.
+                Use `create_navigation(nav_group.children, expandable=True)` for the nested nav levels to expand only when parent page is active.
+              #}
+              {{ create_navigation(nav_group.children, expandable=False) }}
             {% endif %}
-            {#
-              Use `create_navigation(nav_group.children)` for a default, fully expanded navigation.
-              Use `create_navigation(nav_group.children, expandable=True)` for the nested nav levels to expand only when parent page is active.
-            #}
-            {{ create_navigation(nav_group.children, expandable=True) }}
-          {% endif %}
-        {% endfor %}
+          {% endfor %}
         </div>
-      </nav>
-    </div>
-  </div>
-
-  {#
-    TITLE AREA
-    Contains page title (and possibly any other information to be displayed with it).
-    Rendered above table of contents on smaller screens.
-  #}
-  <div class="l-docs__title">
-    <div class="u-fixed-width">
-      {% if document.title %}
-      <div class="p-section--shallow u-no-padding--top">
-        <h1 class="u-no-margin--bottom">{{ document.title }}</h1>
       </div>
-      {% endif %}
-    </div>
-  </div>
+    </aside>
 
-  {#
-    TABLE OF CONTENTS AREA
-    Contains table of contents (and possibly any other meta data).
-    Rendered on the right side of the page on larger screens, or between title and main content on smaller screens.
-  #}
-  {% if document.headings_map is defined and document.headings_map|length > 0 %}
-    <div class="l-docs__meta">
-      <div class="l-docs__sticky-container">
-        <aside class="p-table-of-contents">
-          <div class="p-table-of-contents__section">
-            <h4 class="p-table-of-contents__header">On this page</h4>
-            <nav class="p-table-of-contents__nav" aria-label="Table of contents">
-              <ul class="p-table-of-contents__list">
-                {% for heading in document.headings_map %}
-                <li class="p-table-of-contents__item"><a class="p-table-of-contents__link" href="#{{ heading.heading_slug }}">{{ heading.heading_text }}</a></li>
-                {% endfor %}
-              </ul>
-            </nav>
-          </div>
-        </aside>
-      </div>
-    </div>
-  {% endif %}
-
-
-  {#
-    MAIN CONTENT AREA
-    Contains content of the document.
-  #}
-  <div class="l-docs__main u-text-max-width">
-    <main class="u-fixed-width">
-      <div class="p-strip is-shallow" style="overflow: visible;">
+    <main class="col-9">
       {{ document.body_html | safe }}
-      </div>
 
       <div class="p-strip is-shallow">
         <div class="p-notification--information">
@@ -172,13 +97,6 @@
         </div>
       </div>
     </main>
-  </div>
-
-  {#
-    FOOTER AREA
-  #}
-  <div class="l-docs__footer">
-    {% include "_footer.html" %}
   </div>
 </div>
 


### PR DESCRIPTION
With new documentation layout being introduced in Vanilla 4.5.0 and tested already on mikrok8s website this provides an example and documentation on how to use it for Flask and Discourse based documentation sites.

Fixes [WD-6056](https://warthogs.atlassian.net/browse/WD-6056)

### QA

- review provided docs and templates, make sure you understand how to use it

[WD-6056]: https://warthogs.atlassian.net/browse/WD-6056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ