### PR TITLE
Adds anchor links to headings

### DIFF
--- a/canonicalwebteam/discourse/parsers/base_parser.py
+++ b/canonicalwebteam/discourse/parsers/base_parser.py
@@ -535,6 +535,7 @@ class BaseParser:
         soup = self._replace_links(soup)
         soup = self._replace_polls(soup)
         soup = self._remove_trailing_numbers_from_headings(soup)
+        soup = self._add_anchor_links(soup)
 
         return soup
 
@@ -827,7 +828,7 @@ class BaseParser:
         eg. "heading-1" -> "heading"
         """
 
-        for heading in soup.find_all(["h1", "h2", "h3", "h4", "h5", "h6"]):
+        for heading in soup.find_all(["h2", "h3"]):
             anchor = heading.find("a", class_="anchor")
             if anchor:
                 anchor_id = anchor.get("name")
@@ -841,4 +842,18 @@ class BaseParser:
                     for link in soup.find_all("a", href=f"#{anchor_id}"):
                         link["href"] = f"#{new_id}"
 
+        return soup
+
+    def _add_anchor_links(self, soup):
+        for heading in soup.find_all(["h2", "h3"]):
+            anchor = heading.find("a", class_="anchor")
+            if anchor:
+                heading_text = heading.get_text()
+                anchor.clear()
+                anchor.append(BeautifulSoup(heading_text, 'html.parser'))
+                anchor["class"] = "p-anchor-link"
+                for content in heading.contents:
+                    if isinstance(content, NavigableString):
+                        content.replace_with("")
+                
         return soup

--- a/canonicalwebteam/discourse/parsers/base_parser.py
+++ b/canonicalwebteam/discourse/parsers/base_parser.py
@@ -850,10 +850,10 @@ class BaseParser:
             if anchor:
                 heading_text = heading.get_text()
                 anchor.clear()
-                anchor.append(BeautifulSoup(heading_text, 'html.parser'))
+                anchor.append(BeautifulSoup(heading_text, "html.parser"))
                 anchor["class"] = "p-link--anchor-heading"
                 for content in heading.contents:
                     if isinstance(content, NavigableString):
                         content.replace_with("")
-                
+
         return soup

--- a/canonicalwebteam/discourse/parsers/base_parser.py
+++ b/canonicalwebteam/discourse/parsers/base_parser.py
@@ -851,7 +851,7 @@ class BaseParser:
                 heading_text = heading.get_text()
                 anchor.clear()
                 anchor.append(BeautifulSoup(heading_text, 'html.parser'))
-                anchor["class"] = "p-anchor-link"
+                anchor["class"] = "p-link--anchor-heading"
                 for content in heading.contents:
                     if isinstance(content, NavigableString):
                         content.replace_with("")


### PR DESCRIPTION
Only merge once Vanilla 3.14.0  drops

## Done

- Adds def to add anchor links to headings similar to what they have on https://developer.mozilla.org/en-US/docs/Web/CSS/visibility#try_it (for example)
 NEW DEMO https://github.com/canonical/ubuntu.com/pull/13989

## QA

- Go to https://ubuntu-com-13989.demos.haus/ceph/docs
- hover a link and see it underlines and a anchor tag appear next to it, see https://staging.vanillaframework.io/docs/patterns/links#anchor-link
- click the link and make sure it is appended to the url

## Issue

https://warthogs.atlassian.net/browse/WD-8606