### PR TITLE
Strip link preview elements

### DIFF
--- a/canonicalwebteam/discourse/parsers/base_parser.py
+++ b/canonicalwebteam/discourse/parsers/base_parser.py
@@ -550,8 +550,14 @@ class BaseParser:
         Given some HTML soup, replace links which look like
         Discourse topic URLs with either the pretty_url in
         the URL map, or the target in the Redirect map,
-        or simply add the any url_prefix to the URL
+        or simply add the any url_prefix to the URL.
+        Also strips any link preview elements
         """
+
+        for preview in soup.find_all("aside", attrs={"data-onebox-src": True}):
+            link = soup.new_tag("a", href=preview["data-onebox-src"])
+            link.string = preview["data-onebox-src"]
+            preview.replace_with(link)
 
         for a in soup.findAll("a"):
             full_link = a.get("href", "")


### PR DESCRIPTION
When a discourse topic has a line that only has a link, it's replaced with a preview element, the parser does not account for this which can cause unexpected layout See https://github.com/canonical/charmhub.io/issues/1807 for an example.

## QA:
- Clone charmhub
- Follow [this guide ](https://discourse.canonical.com/t/how-to-run-our-python-modules-for-local-development/308) to use this branches version of `canonicalwebteam.discourse`
- Check any topic that has a line with only a link, such as the one linked in the issue above.