### PR TITLE
feat: Add function to ensure trailing numbers are removed from heading anchors

### DIFF
--- a/canonicalwebteam/discourse/parsers/base_parser.py
+++ b/canonicalwebteam/discourse/parsers/base_parser.py
@@ -534,6 +534,7 @@ class BaseParser:
         soup = self._replace_image_src(soup)
         soup = self._replace_links(soup)
         soup = self._replace_polls(soup)
+        soup = self._remove_trailing_numbers_from_headings(soup)
 
         return soup
 
@@ -817,5 +818,27 @@ class BaseParser:
                 and "quote" in container.attrs["class"]
             ):
                 container.decompose()
+
+        return soup
+    
+    def _remove_trailing_numbers_from_headings(self, soup):
+        """
+        Given HTML soup, remove trailing numbers from headings.
+        eg. "heading-1" -> "heading"
+        """
+
+        for heading in soup.find_all(['h1', 'h2', 'h3', 'h4', 'h5', 'h6']):
+            anchor = heading.find('a', class_='anchor')
+            if anchor:
+                anchor_id = anchor.get('name')
+                if anchor_id:
+                    new_id = re.sub(r'-\d+$', '', anchor_id)
+
+                    anchor['name'] = new_id
+                    anchor['href'] = f'#{new_id}'
+
+                    # Update any links to this heading within the document
+                    for link in soup.find_all('a', href=f'#{anchor_id}'):
+                        link['href'] = f'#{new_id}'
 
         return soup

--- a/canonicalwebteam/discourse/parsers/base_parser.py
+++ b/canonicalwebteam/discourse/parsers/base_parser.py
@@ -820,25 +820,25 @@ class BaseParser:
                 container.decompose()
 
         return soup
-    
+
     def _remove_trailing_numbers_from_headings(self, soup):
         """
         Given HTML soup, remove trailing numbers from headings.
         eg. "heading-1" -> "heading"
         """
 
-        for heading in soup.find_all(['h1', 'h2', 'h3', 'h4', 'h5', 'h6']):
-            anchor = heading.find('a', class_='anchor')
+        for heading in soup.find_all(["h1", "h2", "h3", "h4", "h5", "h6"]):
+            anchor = heading.find("a", class_="anchor")
             if anchor:
-                anchor_id = anchor.get('name')
+                anchor_id = anchor.get("name")
                 if anchor_id:
-                    new_id = re.sub(r'-\d+$', '', anchor_id)
+                    new_id = re.sub(r"-\d+$", "", anchor_id)
 
-                    anchor['name'] = new_id
-                    anchor['href'] = f'#{new_id}'
+                    anchor["name"] = new_id
+                    anchor["href"] = f"#{new_id}"
 
                     # Update any links to this heading within the document
-                    for link in soup.find_all('a', href=f'#{anchor_id}'):
-                        link['href'] = f'#{new_id}'
+                    for link in soup.find_all("a", href=f"#{anchor_id}"):
+                        link["href"] = f"#{new_id}"
 
         return soup


### PR DESCRIPTION
## Done

- Adds a function `_remove_trailing_numbers_from_headings` to the base soup parser that ensure trailing numbers are removed from heading anchors

## QA

- Run a project that leverages discourse docs locally ie. ubuntu.com
- Specify this branch as the requirement for `canonicalwebteam.discourse`, it will look something like:
```
canonicalwebteam.discourse @ git+https://github.com/canonical/canonicalwebteam.discourse@remove-trailing-numbers
```
- Run `dotrun clean` to remove any old packages and then `dotrun` to reinstall
- If that doesn't work you can download the canonicalwebteam.discourse and check out this branch and then add 
```
-e ../canonicalwebteam.discourse
```
where the requirement for `canonicalwebteam.discourse` would be (I'm assuming they live in the same folder here)

- Once it is running with this branch, do to any docs page and check that the headings contain an anchor that doesn't have a trailing number.
eg.
```
<h2><a class="anchor" href="#in-this-documentation" name="in-this-documentation"></a>In this documentation</h2>
```
