### PR TITLE
Add limit and offset to allow pagination for engage pages and takeovers

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,7 @@ Similarly for takeovers, you just need to pass `page_type="takeovers"`.
 
 - To get a list of takeovers `EngagePages(args).get_index()` also.
 - To get a list of active takeovers `EngagePages(args).parse_active_takeovers()`.
+
+## Pagination
+- `get_index` provides two additional arguments `limit` and `offset`, to provide pagination functionality. They default to 50 and 0 respectively.
+- Use `MaxLimitError` in the `exceptions.py` to handle excessive limit. By default, it will raise an error when it surpasses 500

--- a/canonicalwebteam/discourse/app.py
+++ b/canonicalwebteam/discourse/app.py
@@ -308,14 +308,16 @@ class EngagePages(BaseParser):
         self.additional_metadata_validation = additional_metadata_validation
         pass
 
-    def get_index(self):
+    def get_index(self, limit=50, offset=0):
         """
         Get the index topic and split it into:
         - index document content
         - URL map
         And set those as properties on this object
         """
-        list_topics = self.api.engage_pages_by_category(self.category_id)
+        list_topics = self.api.engage_pages_by_category(
+            self.category_id, limit, offset
+        )
         topics = []
         for topic in list_topics:
             if topic[6] not in self.exclude_topics:

--- a/canonicalwebteam/discourse/exceptions.py
+++ b/canonicalwebteam/discourse/exceptions.py
@@ -62,4 +62,25 @@ class MarkdownError(Exception):
 
 
 class DataExplorerError(Exception):
+    """
+    Errors raised when the Data Explorer plugin for Discourse
+    returns an error.
+
+    Will be sent to Sentry
+    """
+
+    def __init__(self, *args: object) -> None:
+        error_message = args[0]
+        flask.current_app.extensions["sentry"].captureMessage(
+            f"Engage pages Data Explorer error {error_message}"
+        )
+        pass
+
+
+class MaxLimitError(Exception):
+    """
+    Error raised when limit/offset is too high
+    most likely spamming.
+    """
+
     pass

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse",
-    version="5.6.1",
+    version="5.7.1",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical/canonicalwebteam.discourse",

--- a/tests/cassettes/TestDiscourseAPI.test_index_ep_takeovers.yaml
+++ b/tests/cassettes/TestDiscourseAPI.test_index_ep_takeovers.yaml
@@ -1,0 +1,55 @@
+interactions:
+- request:
+    body: params=%7B%22category_id%22%3A+%2250%22%2C+%22limit%22%3A+%2250%22%2C+%22offset%22%3A+%220%22%7D
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '96'
+      Content-Type:
+      - multipart/form-data;
+      User-Agent:
+      - python-requests/2.32.3
+    method: POST
+    uri: https://discourse.ubuntu.com/admin/plugins/explorer/queries/14/run
+  response:
+    body:
+      string: "{\"success\": true, \"errors\": [], \"duration\": 12.5, \"result_count\": 1, \"params\": {\"category_id\": 51, \"limit\": \"1\", \"offset\": \"0\"}, \"rows\": [[\"test metadata table\"]]}"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Wed, 10 Jul 2024 12:35:59 GMT
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Set-Cookie:
+      - DISCOURSE-K8S_AFFINITY=1720614960.234.50.132029|758aaddbd3331dc0c8b13bfc67634cb7;
+        Max-Age=3600; Path=/; Secure; HttpOnly; SameSite=Lax
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Request-Id:
+      - e6a993dbe7af79190d387d6d8aac84a1
+      X-Runtime:
+      - '0.005133'
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/TestDiscourseAPI.test_individual_ep_takeovers.yaml
+++ b/tests/cassettes/TestDiscourseAPI.test_individual_ep_takeovers.yaml
@@ -1,0 +1,56 @@
+interactions:
+- request:
+    body: params=%7B%22category_id%22%3A+%2251%22%2C+%22keyword%22%3A+%22active%22%2C+%22value%22%3A+%22true%22%2C+%22limit%22%3A+%2250%22%2C+%22offset%22%3A+%220%22%7D
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '158'
+      Content-Type:
+      - multipart/form-data;
+      User-Agent:
+      - python-requests/2.32.3
+    method: POST
+    uri: https://discourse.ubuntu.com/admin/plugins/explorer/queries/16/run
+  response:
+    body:
+      string: "{\"success\": true, \"errors\": [], \"duration\": 12.5, \"result_count\": 1, \"params\": {\"category_id\": 51, \"limit\": \"1\", \"offset\": \"0\"}, \"rows\": [[\"test metadata table\"]]}"
+
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Wed, 10 Jul 2024 12:53:22 GMT
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Set-Cookie:
+      - DISCOURSE-K8S_AFFINITY=1720616003.069.63.255833|758aaddbd3331dc0c8b13bfc67634cb7;
+        Max-Age=3600; Path=/; Secure; HttpOnly; SameSite=Lax
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Request-Id:
+      - 9b2bb8a749b5a5e836f38ff8f6fd5be5
+      X-Runtime:
+      - '0.003923'
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/TestDiscourseAPI.test_pagination.yaml
+++ b/tests/cassettes/TestDiscourseAPI.test_pagination.yaml
@@ -1,0 +1,55 @@
+interactions:
+- request:
+    body: params=%7B%22category_id%22%3A+%2251%22%2C+%22limit%22%3A+%221%22%2C+%22offset%22%3A+%220%22%7D
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '95'
+      Content-Type:
+      - multipart/form-data;
+      User-Agent:
+      - python-requests/2.32.3
+    method: POST
+    uri: https://discourse.ubuntu.com/admin/plugins/explorer/queries/14/run
+  response:
+    body:
+      string: "{\"success\": true, \"errors\": [], \"duration\": 12.5, \"result_count\": 1, \"params\": {\"category_id\": 51, \"limit\": \"1\", \"offset\": \"0\"}, \"rows\": [[\"test metadata table\"]]}"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Tue, 02 Jul 2024 10:32:34 GMT
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Set-Cookie:
+      - DISCOURSE-K8S_AFFINITY=1719916355.654.10737.274478|758aaddbd3331dc0c8b13bfc67634cb7;
+        Max-Age=3600; Path=/; Secure; HttpOnly; SameSite=Lax
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Request-Id:
+      - 380c23277fb8e1bafc0dd84b5ae4a875
+      X-Runtime:
+      - '0.004855'
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1


### PR DESCRIPTION
## Done

Add support for pagination for engage pages and takeovers


## QA

- Go to https://ubuntu-com-14035.demos.haus/engage
- Add pagination with the URL https://ubuntu-com-14035.demos.haus/engage?limit=5&offset=0
- Go to next page https://ubuntu-com-14035.demos.haus/engage?limit=5&offset=1 and check that items of the following page display correctly

## Issue

Fixes https://warthogs.atlassian.net/browse/WD-7149
Fixes https://warthogs.atlassian.net/browse/WD-7150