### PR TITLE
bug: Fix bug where if a code block is nested in the heading it gets duplicated

### DIFF
--- a/canonicalwebteam/discourse/parsers/base_parser.py
+++ b/canonicalwebteam/discourse/parsers/base_parser.py
@@ -848,12 +848,12 @@ class BaseParser:
         for heading in soup.find_all(["h2", "h3"]):
             anchor = heading.find("a", class_="anchor")
             if anchor:
-                heading_text = heading.get_text()
+                heading_children = [child for child in heading.children if child != anchor]
                 anchor.clear()
-                anchor.append(BeautifulSoup(heading_text, "html.parser"))
+                for child in heading_children:
+                    anchor.append(child)
                 anchor["class"] = "p-link--anchor-heading"
-                for content in heading.contents:
-                    if isinstance(content, NavigableString):
-                        content.replace_with("")
+                heading.clear()
+                heading.append(anchor)
 
         return soup

--- a/canonicalwebteam/discourse/parsers/base_parser.py
+++ b/canonicalwebteam/discourse/parsers/base_parser.py
@@ -848,7 +848,9 @@ class BaseParser:
         for heading in soup.find_all(["h2", "h3"]):
             anchor = heading.find("a", class_="anchor")
             if anchor:
-                heading_children = [child for child in heading.children if child != anchor]
+                heading_children = [
+                    child for child in heading.children if child != anchor
+                ]
                 anchor.clear()
                 for child in heading_children:
                     anchor.append(child)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse",
-    version="5.6.0",
+    version="5.6.1",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical/canonicalwebteam.discourse",


### PR DESCRIPTION
## Done

- This fixed a bug we had in the `_add_anchor_links` func, where headings that had nested content ex. `<h3><code>something</code></h3>` would be duplicated. You can see it here: https://juju.is/docs/juju/hook-tool?efgh
- I changed how we handle the headings so nested content is retained

## QA

- Go to https://ubuntu-com-14036.demos.haus/ceph/docs/setting-up-multi-site and see that the heading 'Prerequisites' is not duplicated and is clickable/hover-able as an anchor link
- Check other headings still retain the functionality