### PR TITLE
Add sort by functionality to takeovers 'cooked' content

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,4 +96,5 @@ Similarly for takeovers, you just need to pass `page_type="takeovers"`.
 
 ## Pagination
 - `get_index` provides two additional arguments `limit` and `offset`, to provide pagination functionality. They default to 50 and 0 respectively.
+- If you want to get all engage pages, which in the case of some sites like jp.ubuntu.com there are not that many, you can pass `limit=-1`
 - Use `MaxLimitError` in the `exceptions.py` to handle excessive limit. By default, it will raise an error when it surpasses 500

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse",
-    version="5.7.1",
+    version="5.7.2",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical/canonicalwebteam.discourse",

--- a/tests/cassettes/TestDiscourseAPI.test_index_ep_takeovers.yaml
+++ b/tests/cassettes/TestDiscourseAPI.test_index_ep_takeovers.yaml
@@ -15,7 +15,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: POST
-    uri: https://discourse.ubuntu.com/admin/plugins/explorer/queries/14/run
+    uri: https://discourse.ubuntu.com/admin/plugins/explorer/queries/16/run
   response:
     body:
       string: "{\"success\": true, \"errors\": [], \"duration\": 12.5, \"result_count\": 1, \"params\": {\"category_id\": 51, \"limit\": \"1\", \"offset\": \"0\"}, \"rows\": [[\"test metadata table\"]]}"

--- a/tests/cassettes/TestDiscourseAPI.test_pagination.yaml
+++ b/tests/cassettes/TestDiscourseAPI.test_pagination.yaml
@@ -15,7 +15,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: POST
-    uri: https://discourse.ubuntu.com/admin/plugins/explorer/queries/14/run
+    uri: https://discourse.ubuntu.com/admin/plugins/explorer/queries/16/run
   response:
     body:
       string: "{\"success\": true, \"errors\": [], \"duration\": 12.5, \"result_count\": 1, \"params\": {\"category_id\": 51, \"limit\": \"1\", \"offset\": \"0\"}, \"rows\": [[\"test metadata table\"]]}"

--- a/tests/test_engage_pages.py
+++ b/tests/test_engage_pages.py
@@ -5,7 +5,6 @@ import flask
 from vcr_unittest import VCRTestCase
 
 from canonicalwebteam.discourse import DiscourseAPI, EngagePages
-from canonicalwebteam.discourse.exceptions import MaxLimitError
 
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
@@ -55,7 +54,7 @@ class TestDiscourseAPI(VCRTestCase):
         Test endpoint that retrieves all takeovers/engage pages
         """
 
-        response = self.discourse_api.engage_pages_by_category()
+        response = self.discourse_api.get_engage_pages_by_param(51)
         self.assertEqual(len(response), 1)
 
     def test_individual_ep_takeovers(self):
@@ -64,7 +63,7 @@ class TestDiscourseAPI(VCRTestCase):
         """
 
         response = self.discourse_api.get_engage_pages_by_param(
-            51, "active", "true"
+            category_id=51, key="active", value="true"
         )
 
         self.assertEqual(len(response), 1)
@@ -77,20 +76,8 @@ class TestDiscourseAPI(VCRTestCase):
         - category_id=51, should always be 51 for
         https://discourse.ubuntu.com/c/design/engage-pages/51
         """
-        response = self.discourse_api.engage_pages_by_category(
-            limit=1, offset=0
+        response = self.discourse_api.get_engage_pages_by_param(
+            category_id=51, limit=1, offset=0
         )
 
         self.assertEqual(len(response), 1)
-
-    def test_max_limit_error(self):
-        """
-        Test pagination limit abuse
-        """
-
-        self.assertRaises(
-            MaxLimitError,
-            self.discourse_api.engage_pages_by_category,
-            limit=1000,
-            offset=0,
-        )


### PR DESCRIPTION
## Done
- Added sort functionality, order by active -> true and 
- Refactored data explorer query into single one `query_engage_pages_by_param`
- Added count active query that works with pagination.
- Added total count of pages
- Added total count of all items
Most of this work done in [data explorer](https://discourse.ubuntu.com/admin/plugins/explorer?id=16)

## QA

1. Go to https://ubuntu-com-14035.demos.haus/engage
2. Scroll down and click next page and/or the numbers to check that next page doesn't repeat the same engage pages.
3. Select language, and check that the correct language of engage pages shows
4. Same for resource types and tags

Do the steps 1 and 2 for https://ubuntu-com-14035.demos.haus/takeovers
Check for https://ubuntu-com-14035.demos.haus/takeovers.json works as usual. 
Test security limits e.g. limit=2000