### PR TITLE
chore: Bump version to 5.7.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse",
-    version="5.7.2",
+    version="5.7.3",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical/canonicalwebteam.discourse",


### PR DESCRIPTION
Apply changes from https://github.com/canonical/canonicalwebteam.discourse/pull/197 and bump version to 5.7.3