### PR TITLE
Include h3 to table of contents

### DIFF
--- a/examples/document.html
+++ b/examples/document.html
@@ -143,7 +143,14 @@
             <nav class="p-table-of-contents__nav" aria-label="Table of contents">
               <ul class="p-table-of-contents__list">
                 {% for heading in document.headings_map %}
-                <li class="p-table-of-contents__item"><a class="p-table-of-contents__link" href="#{{ heading.heading_slug }}">{{ heading.heading_text }}</a></li>
+                  <li class="p-table-of-contents__item"><a class="p-table-of-contents__link" href="#{{ heading.heading_slug }}">{{ heading.heading_text }}</a></li>
+                  {% if heading.children %}
+                    <ul class="p-table-of-contents__list">
+                    {% for child in heading.children %}
+                      <li class="p-table-of-contents__item"><a class="p-table-of-contents__link" href="#{{ child.heading_slug }}">{{ child.heading_text }}</a></li>
+                      {% endfor %}
+                    </ul>
+                  {% endif %}
                 {% endfor %}
               </ul>
             </nav>


### PR DESCRIPTION
Include h3 headings to docs table of contents. Nest h3 items within their corresponding h2 parent headings.

This is a duplicated fix that was addressed here: https://github.com/canonical/juju.is/pull/564
Updating the Discourse repo for consistency!

Fixes https://github.com/canonical/canonicalwebteam.discourse/issues/187