### PR TITLE
feat: Update query to include second keyword and value

### DIFF
--- a/canonicalwebteam/discourse/app.py
+++ b/canonicalwebteam/discourse/app.py
@@ -308,7 +308,10 @@ class EngagePages(BaseParser):
         self.additional_metadata_validation = additional_metadata_validation
         pass
 
-    def get_index(self, limit=50, offset=0, key=None, value=None):
+    def get_index(
+            self, limit=50, offset=0, key=None, value=None,
+            second_key=None, second_value=None
+    ):
         """
         Get the index topic and split it into:
         - index document content
@@ -321,6 +324,16 @@ class EngagePages(BaseParser):
                 limit=limit,
                 offset=offset,
                 tag=value,
+            )
+        elif second_key:
+            list_topics = self.api.get_engage_pages_by_param(
+                category_id=self.category_id,
+                limit=limit,
+                offset=offset,
+                key=key,
+                value=value,
+                second_key=second_key,
+                second_value=second_value,
             )
         else:
             list_topics = self.api.get_engage_pages_by_param(

--- a/canonicalwebteam/discourse/app.py
+++ b/canonicalwebteam/discourse/app.py
@@ -309,8 +309,13 @@ class EngagePages(BaseParser):
         pass
 
     def get_index(
-            self, limit=50, offset=0, key=None, value=None,
-            second_key=None, second_value=None
+        self,
+        limit=50,
+        offset=0,
+        key=None,
+        value=None,
+        second_key=None,
+        second_value=None,
     ):
         """
         Get the index topic and split it into:

--- a/canonicalwebteam/discourse/app.py
+++ b/canonicalwebteam/discourse/app.py
@@ -330,7 +330,7 @@ class EngagePages(BaseParser):
                 offset=offset,
                 tag=value,
             )
-        elif second_key:
+        elif key and second_key:
             list_topics = self.api.get_engage_pages_by_param(
                 category_id=self.category_id,
                 limit=limit,

--- a/canonicalwebteam/discourse/models.py
+++ b/canonicalwebteam/discourse/models.py
@@ -139,7 +139,7 @@ class DiscourseAPI:
             },
         )
 
-        if second_key and second_value:
+        if key and value and second_key and second_value:
             params = (
                 {
                     "params": (

--- a/canonicalwebteam/discourse/models.py
+++ b/canonicalwebteam/discourse/models.py
@@ -83,8 +83,14 @@ class DiscourseAPI:
         return response.json()
 
     def get_engage_pages_by_param(
-        self, category_id, key=None, value=None, limit=50, offset=0,
-        second_key=None, second_value=None
+        self,
+        category_id,
+        key=None,
+        value=None,
+        limit=50,
+        offset=0,
+        second_key=None,
+        second_value=None,
     ):
         """
         Uses data-explorer to query topics with the category

--- a/canonicalwebteam/discourse/models.py
+++ b/canonicalwebteam/discourse/models.py
@@ -83,7 +83,8 @@ class DiscourseAPI:
         return response.json()
 
     def get_engage_pages_by_param(
-        self, category_id, key=None, value=None, limit=50, offset=0
+        self, category_id, key=None, value=None, limit=50, offset=0,
+        second_key=None, second_value=None
     ):
         """
         Uses data-explorer to query topics with the category
@@ -132,7 +133,19 @@ class DiscourseAPI:
             },
         )
 
-        if key and value:
+        if second_key and second_value:
+            params = (
+                {
+                    "params": (
+                        f'{{"category_id":"{category_id}", '
+                        f'"keyword":"{key}", "value":"{value}", '
+                        f'"second_keyword":"{second_key}", '
+                        f'"second_value":"{second_value}", '
+                        f'"limit":"{limit}", "offset":"{offset}"}}'
+                    )
+                },
+            )
+        elif key and value:
             params = (
                 {
                     "params": (

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse",
-    version="5.7.3",
+    version="5.7.4",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical/canonicalwebteam.discourse",


### PR DESCRIPTION
Updated `query_engage_page_by_param` to include second keyword and value.
This is to allow Engage pages to be queried for multiple type and languages