### PR TITLE
feat(Category): Remove template handling from the Category class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 5.9.0 [28-01-2025]
+**Updated** Category class 
+Removed to template handling from within the Category class
+
 ### 5.8.0 [28-01-2025]
 **Added** Category class 
 A generic class for processing discourse categories and the topics they contain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-### 5.9.0 [28-01-2025]
+### 6.0.0 [28-01-2025]
 **Updated** Category class 
-Removed to template handling from within the Category class
+Removed to template handling from within the Category class.
+Bump to 6.0.0, as the previous update was a major
 
 ### 5.8.0 [28-01-2025]
 **Added** Category class 

--- a/canonicalwebteam/discourse/app.py
+++ b/canonicalwebteam/discourse/app.py
@@ -724,6 +724,9 @@ class Category:
         self.exclude_topics = exclude_topics
         self.category_topics = []
         self.parser.parse_index_topic()
+        self.last_updated = self.parser.api.get_last_activity_time(
+            self.parser.index_topic_id
+        )[0][1]
         pass
 
     def get_topic(self, path=""):
@@ -760,10 +763,13 @@ class Category:
 
     def get_category_index_metadata(self, data_name=""):
         """
-        Exposes an API to query category metadata
+        Exposes an API to query category metadata.
+        Check if the index topic has been updated and refresh the metadata
 
         :param data_name: Name of the data table
         """
+        if self._check_for_topic_updates(self.parser.index_topic_id):
+            self.parser.parse_index_topic()
         if data_name:
             return self.parser.category_index_metadata[data_name]
         else:
@@ -778,3 +784,14 @@ class Category:
         )
         topics_map = {str(topic[0]): topic[2] for topic in topics_list}
         return topics_map
+
+    def _check_for_topic_updates(self, topic_id):
+        """
+        Check if the index topic has been updated
+        """
+        most_recent_update = self.parser.api.get_last_activity_time(topic_id)[
+            0
+        ][1]
+        if most_recent_update > self.last_updated:
+            return True
+        pass

--- a/canonicalwebteam/discourse/app.py
+++ b/canonicalwebteam/discourse/app.py
@@ -759,17 +759,17 @@ class Category:
     def get_category_index_metadata(self, data_name=""):
         """
         Exposes an API to query category metadata.
-        Checks if the index topic has been updated or is undefined and 
+        Checks if the index topic has been updated or is undefined and
         then fetches/refreshes the metadata
 
         :param data_name: Name of the data table
         """
         if (
-            self.category_index_metadata is None 
+            self.category_index_metadata is None
             or self._check_for_topic_updates(self.parser.index_topic_id)
         ):
             self.parse_index_topic()
-        
+
         if data_name:
             return self.category_index_metadata.get(data_name)
         else:
@@ -793,8 +793,7 @@ class Category:
             self.category_topics = self.parser.api.get_topic_list_by_category(
                 self.category_id
             )
-        return  {str(topic[0]): topic[2] for topic in self.category_topics}
-        
+        return {str(topic[0]): topic[2] for topic in self.category_topics}
 
     def _check_for_topic_updates(self, topic_id):
         """

--- a/canonicalwebteam/discourse/app.py
+++ b/canonicalwebteam/discourse/app.py
@@ -697,7 +697,7 @@ class EngagePages(BaseParser):
         pass
 
 
-class Category(Discourse):
+class Category:
     """
     Given a category id and CategoryParser takes any data tables found in the
     index topic and stores the data in a dictionary.
@@ -717,12 +717,8 @@ class Category(Discourse):
         self,
         parser,
         category_id,
-        url_prefix,
-        document_template,
-        blueprint_name,
         exclude_topics=[],
     ):
-        super().__init__(parser, document_template, url_prefix, blueprint_name)
         self.parser = parser
         self.category_id = category_id
         self.exclude_topics = exclude_topics
@@ -730,47 +726,42 @@ class Category(Discourse):
         self.parser.parse_index_topic()
         pass
 
-        @self.blueprint.route("/")
-        @self.blueprint.route("/<path:path>")
-        def document_view(path=""):
-            """
-            A Flask view function to serve topics from a Discourse category
-            """
-            path = "/" + path
-            if path == "/":
-                document = self.parser.parse_topic(self.parser.index_topic)
-            else:
-                try:
-                    topic_id = self._get_topic_id_from_path(path)
-                except PathNotFoundError:
-                    return flask.abort(404)
+    def get_topic(self, path=""):
+        """
+        A Flask view function to serve topics from a Discourse category
+        """
+        path = "/" + path
+        if path == "/":
+            document = self.parser.parse_topic(self.parser.index_topic)
+        else:
+            try:
+                topic_id = self._get_topic_id_from_path(path)
+            except PathNotFoundError:
+                return flask.abort(404)
 
-                if topic_id == self.parser.index_topic_id:
-                    return flask.redirect(self.url_prefix)
+            if topic_id == self.parser.index_topic_id:
+                return flask.redirect(self.url_prefix)
 
-                try:
-                    topic = self.parser.api.get_topic(topic_id)
-                except HTTPError as http_error:
-                    return flask.abort(http_error.response.status_code)
+            try:
+                topic = self.parser.api.get_topic(topic_id)
+            except HTTPError as http_error:
+                return flask.abort(http_error.response.status_code)
 
-                document = self.parser.parse_topic(topic)
+            document = self.parser.parse_topic(topic)
 
-            template = flask.render_template(
-                document_template,
-                category_index_metadata=self.parser.category_index_metadata,
-                document=document,
-            )
-            return flask.make_response(template)
+        return document
 
     def _get_topic_id_from_path(self, path):
         path = path.lstrip("/")
-        category_topics = self._query_category_topics()
+        category_topics = self.parser.api.get_topic_list_by_category(
+            self.category_id
+        )
         for topic in category_topics:
             if topic[2] == path:
                 return topic[0]
         return None
 
-    def get_category_index_metadata(self, data_name):
+    def get_category_index_metadata(self, data_name=""):
         """
         Exposes an API to query category metadata
 
@@ -785,19 +776,8 @@ class Category(Discourse):
         """
         Exposes an API to query all topics in a category
         """
-        topics_list = self._query_category_topics()
+        topics_list = self.parser.api.get_topic_list_by_category(
+            self.category_id
+        )
         topics_map = {str(topic[0]): topic[2] for topic in topics_list}
         return topics_map
-
-    def _query_category_topics(self):
-        """
-        Retrieve the category topics list from the api and store it.
-        On subsequent calls, return the stored list.
-        """
-        if self.category_topics:
-            return self.category_topics
-        else:
-            self.category_topics = self.parser.api.get_topic_list_by_category(
-                self.category_id
-            )
-            return self.category_topics

--- a/canonicalwebteam/discourse/app.py
+++ b/canonicalwebteam/discourse/app.py
@@ -739,9 +739,6 @@ class Category:
             except PathNotFoundError:
                 return flask.abort(404)
 
-            if topic_id == self.parser.index_topic_id:
-                return flask.redirect(self.url_prefix)
-
             try:
                 topic = self.parser.api.get_topic(topic_id)
             except HTTPError as http_error:

--- a/canonicalwebteam/discourse/models.py
+++ b/canonicalwebteam/discourse/models.py
@@ -121,6 +121,31 @@ class DiscourseAPI:
 
         return result["rows"]
 
+    def get_last_activity_time(self, topic_id):
+        """
+        Uses data-explorer to the last time a specifc topic was updated
+
+        Args:
+        - topic_id [int]: The topic ID
+        """
+        # See https://discourse.ubuntu.com/admin/plugins/explorer?id=122
+        data_explorer_id = 122
+        headers = {
+            "Accept": "application/json",
+            "Content-Type": "multipart/form-data;",
+        }
+        params = ({"params": (f'{{"topic_id":"{topic_id}"}} ')},)
+        response = self.session.post(
+            f"{self.base_url}/admin/plugins/explorer/"
+            f"queries/{data_explorer_id}/run",
+            headers=headers,
+            data=params[0],
+        )
+        response.raise_for_status()
+        result = response.json()
+
+        return result["rows"]
+
     def get_engage_pages_by_param(
         self,
         category_id,

--- a/canonicalwebteam/discourse/parsers/category.py
+++ b/canonicalwebteam/discourse/parsers/category.py
@@ -14,7 +14,6 @@ class CategoryParser(BaseParser):
     """
 
     def __init__(self, api, index_topic_id, url_prefix):
-        self.category_metadata = None
         return super().__init__(api, index_topic_id, url_prefix)
 
     def parse_index_topic(self):
@@ -43,7 +42,7 @@ class CategoryParser(BaseParser):
             if next_table:
                 data_tables[section_name] = self._parse_table(next_table)
 
-        self.category_index_metadata = data_tables
+        return data_tables
 
     def _parse_table(self, table):
         """

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse",
-    version="5.8.0",
+    version="5.9.0",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical/canonicalwebteam.discourse",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse",
-    version="5.9.0",
+    version="6.0.0",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical/canonicalwebteam.discourse",


### PR DESCRIPTION
## Done

- Remove template handling from the Category class. Templates should now be handled by the project that is using the module. This gives greater flexibility to the usage of the class.
- Add a new discourse query `get_last_activity_time` to know whether to update the content without a rebuild. Uses the data explore plugin here https://discourse.ubuntu.com/admin/plugins/explorer?id=122

## QA

- Check out [the demo](https://ubuntu-com-14726.demos.haus/security/vulnerabilities) and see the vulnerability pages are still being rendered.  
