### PR TITLE
feat: Add third filter for querying engage pages

### DIFF
--- a/canonicalwebteam/discourse/app.py
+++ b/canonicalwebteam/discourse/app.py
@@ -316,6 +316,8 @@ class EngagePages(BaseParser):
         value=None,
         second_key=None,
         second_value=None,
+        third_key=None,
+        third_value=None,
     ):
         """
         Get the index topic and split it into:
@@ -329,6 +331,18 @@ class EngagePages(BaseParser):
                 limit=limit,
                 offset=offset,
                 tag=value,
+            )
+        elif key and second_key and third_key:
+            list_topics = self.api.get_engage_pages_by_param(
+                category_id=self.category_id,
+                limit=limit,
+                offset=offset,
+                key=key,
+                value=value,
+                second_key=second_key,
+                second_value=second_value,
+                third_key=third_key,
+                third_value=third_value,
             )
         elif key and second_key:
             list_topics = self.api.get_engage_pages_by_param(

--- a/canonicalwebteam/discourse/app.py
+++ b/canonicalwebteam/discourse/app.py
@@ -324,53 +324,29 @@ class EngagePages(BaseParser):
         - URL map
         And set those as properties on this object
         """
-        if tag_value:
-            if key:
-                if second_key:
-                    list_topics = self.api.get_engage_pages_by_param(
-                        category_id=self.category_id,
-                        limit=limit,
-                        offset=offset,
-                        tag_value=tag_value,
-                        key=key,
-                        value=value,
-                        second_key=second_key,
-                        second_value=second_value,
-                    )
-                else:
-                    list_topics = self.api.get_engage_pages_by_param(
-                        category_id=self.category_id,
-                        limit=limit,
-                        offset=offset,
-                        tag_value=tag_value,
-                        key=key,
-                        value=value,
-                    )
-            else:
-                list_topics = self.api.get_engage_pages_by_tag(
-                    category_id=self.category_id,
-                    limit=limit,
-                    offset=offset,
-                    tag=tag_value,
-                )
-        elif key and second_key:
-            list_topics = self.api.get_engage_pages_by_param(
+
+        params = {
+            "category_id": self.category_id,
+            "limit": limit,
+            "offset": offset,
+            "tag_value": tag_value,
+            "key": key,
+            "value": value,
+            "second_key": second_key,
+            "second_value": second_value,
+        }
+
+        params = {k: v for k, v in params.items() if v is not None}
+
+        if tag_value and not value and not second_value:
+            list_topics = self.api.get_engage_pages_by_tag(
                 category_id=self.category_id,
                 limit=limit,
                 offset=offset,
-                key=key,
-                value=value,
-                second_key=second_key,
-                second_value=second_value,
+                tag=tag_value,
             )
         else:
-            list_topics = self.api.get_engage_pages_by_param(
-                category_id=self.category_id,
-                limit=limit,
-                offset=offset,
-                key=key,
-                value=value,
-            )
+            list_topics = self.api.get_engage_pages_by_param(**params)
 
         topics = []
         for topic in list_topics:

--- a/canonicalwebteam/discourse/app.py
+++ b/canonicalwebteam/discourse/app.py
@@ -312,12 +312,11 @@ class EngagePages(BaseParser):
         self,
         limit=50,
         offset=0,
+        tag_value=None,
         key=None,
         value=None,
         second_key=None,
         second_value=None,
-        third_key=None,
-        third_value=None,
     ):
         """
         Get the index topic and split it into:
@@ -325,25 +324,35 @@ class EngagePages(BaseParser):
         - URL map
         And set those as properties on this object
         """
-        if key == "tag":
-            list_topics = self.api.get_engage_pages_by_tag(
-                category_id=self.category_id,
-                limit=limit,
-                offset=offset,
-                tag=value,
-            )
-        elif key and second_key and third_key:
-            list_topics = self.api.get_engage_pages_by_param(
-                category_id=self.category_id,
-                limit=limit,
-                offset=offset,
-                key=key,
-                value=value,
-                second_key=second_key,
-                second_value=second_value,
-                third_key=third_key,
-                third_value=third_value,
-            )
+        if tag_value:
+            if key:
+                if second_key:
+                    list_topics = self.api.get_engage_pages_by_param(
+                        category_id=self.category_id,
+                        limit=limit,
+                        offset=offset,
+                        tag_value=tag_value,
+                        key=key,
+                        value=value,
+                        second_key=second_key,
+                        second_value=second_value,
+                    )
+                else:
+                    list_topics = self.api.get_engage_pages_by_param(
+                        category_id=self.category_id,
+                        limit=limit,
+                        offset=offset,
+                        tag_value=tag_value,
+                        key=key,
+                        value=value,
+                    )
+            else:
+                list_topics = self.api.get_engage_pages_by_tag(
+                    category_id=self.category_id,
+                    limit=limit,
+                    offset=offset,
+                    tag=tag_value,
+                )
         elif key and second_key:
             list_topics = self.api.get_engage_pages_by_param(
                 category_id=self.category_id,

--- a/canonicalwebteam/discourse/models.py
+++ b/canonicalwebteam/discourse/models.py
@@ -1,4 +1,5 @@
 from canonicalwebteam.discourse.exceptions import DataExplorerError
+import json
 
 
 class DiscourseAPI:
@@ -170,80 +171,31 @@ class DiscourseAPI:
         # See https://discourse.ubuntu.com/admin/plugins/explorer?id=16
         data_explorer_id = 16
 
-        params = (
-            {
-                "params": (
-                    f'{{"category_id":"{category_id}", '
-                    f'"limit":"{limit}", "offset":"{offset}"}}'
-                )
-            },
-        )
+        params_dict = {
+            "category_id": str(category_id),
+            "limit": str(limit),
+            "offset": str(offset),
+        }
+
         # Tags have to be queried differently due to the way they are stored
         if tag_value:
-            if key and value:
-                if second_key and second_value:
-                    params = (
-                        {
-                            "params": (
-                                f'{{"category_id":"{category_id}", '
-                                f'"tag_value":"{tag_value}", '
-                                f'"keyword":"{key}", "value":"{value}", '
-                                f'"second_keyword":"{second_key}", '
-                                f'"second_value":"{second_value}", '
-                                f'"limit":"{limit}", "offset":"{offset}"}}'
-                            )
-                        },
-                    )
-                else:
-                    params = (
-                        {
-                            "params": (
-                                f'{{"category_id":"{category_id}", '
-                                f'"tag_value":"{tag_value}", '
-                                f'"keyword":"{key}", "value":"{value}", '
-                                f'"limit":"{limit}", "offset":"{offset}"}}'
-                            )
-                        },
-                    )
-            else:
-                params = (
-                    {
-                        "params": (
-                            f'{{"category_id":"{category_id}", '
-                            f'"tag_value":"{tag_value}", '
-                            f'"limit":"{limit}", "offset":"{offset}"}}'
-                        )
-                    },
-                )
-        else:
-            if key and value:
-                if second_key and second_value:
-                    params = (
-                        {
-                            "params": (
-                                f'{{"category_id":"{category_id}", '
-                                f'"keyword":"{key}", "value":"{value}", '
-                                f'"second_keyword":"{second_key}", '
-                                f'"second_value":"{second_value}", '
-                                f'"limit":"{limit}", "offset":"{offset}"}}'
-                            )
-                        },
-                    )
-                else:
-                    params = (
-                        {
-                            "params": (
-                                f'{{"category_id":"{category_id}", '
-                                f'"keyword":"{key}", "value":"{value}", '
-                                f'"limit":"{limit}", "offset":"{offset}"}}'
-                            )
-                        },
-                    )
+            params_dict["tag_value"] = str(tag_value)
 
-            if limit == -1:
-                # Get all engage pages to compile list of tags
-                # last resort if you need to get all pages, not performant
-                params = ({"params": f'{{"category_id":"{category_id}"}}'},)
+        if key and value:
+            params_dict["keyword"] = key
+            params_dict["value"] = value
+
+        if second_key and second_value:
+            params_dict["second_keyword"] = second_key
+            params_dict["second_value"] = second_value
+
+        # Get all engage pages to compile list of tags
+        # last resort if you need to get all pages, not performant
+        if limit == -1:
+            params_dict.pop("limit")
+            params_dict.pop("offset")
+
+        params = ({"params": json.dumps(params_dict)},)
 
         response = self.session.post(
             f"{self.base_url}/admin/plugins/explorer/"

--- a/canonicalwebteam/discourse/models.py
+++ b/canonicalwebteam/discourse/models.py
@@ -130,6 +130,8 @@ class DiscourseAPI:
         offset=0,
         second_key=None,
         second_value=None,
+        third_key=None,
+        third_value=None,
     ):
         """
         Uses data-explorer to query topics with the category
@@ -178,28 +180,47 @@ class DiscourseAPI:
             },
         )
 
-        if key and value and second_key and second_value:
-            params = (
-                {
-                    "params": (
-                        f'{{"category_id":"{category_id}", '
-                        f'"keyword":"{key}", "value":"{value}", '
-                        f'"second_keyword":"{second_key}", '
-                        f'"second_value":"{second_value}", '
-                        f'"limit":"{limit}", "offset":"{offset}"}}'
+        if key and value:
+            if second_key and second_value:
+                # Three filters
+                if third_key and third_value:
+                    params = (
+                        {
+                            "params": (
+                                f'{{"category_id":"{category_id}", '
+                                f'"keyword":"{key}", "value":"{value}", '
+                                f'"second_keyword":"{second_key}", '
+                                f'"second_value":"{second_value}", '
+                                f'"third_keyword":"{third_key}", '
+                                f'"third_value":"{third_value}", '
+                                f'"limit":"{limit}", "offset":"{offset}"}}'
+                            )
+                        },
                     )
-                },
-            )
-        elif key and value:
-            params = (
-                {
-                    "params": (
-                        f'{{"category_id":"{category_id}", '
-                        f'"keyword":"{key}", "value":"{value}", '
-                        f'"limit":"{limit}", "offset":"{offset}"}}'
+                # Two filters
+                else:
+                    params = (
+                        {
+                            "params": (
+                                f'{{"category_id":"{category_id}", '
+                                f'"keyword":"{key}", "value":"{value}", '
+                                f'"second_keyword":"{second_key}", '
+                                f'"second_value":"{second_value}", '
+                                f'"limit":"{limit}", "offset":"{offset}"}}'
+                            )
+                        },
                     )
-                },
-            )
+            # One filter
+            else:
+                params = (
+                    {
+                        "params": (
+                            f'{{"category_id":"{category_id}", '
+                            f'"keyword":"{key}", "value":"{value}", '
+                            f'"limit":"{limit}", "offset":"{offset}"}}'
+                        )
+                    },
+                )
 
         if limit == -1:
             # Get all engage pages to compile list of tags

--- a/canonicalwebteam/discourse/models.py
+++ b/canonicalwebteam/discourse/models.py
@@ -130,8 +130,7 @@ class DiscourseAPI:
         offset=0,
         second_key=None,
         second_value=None,
-        third_key=None,
-        third_value=None,
+        tag_value=None,
     ):
         """
         Uses data-explorer to query topics with the category
@@ -179,11 +178,46 @@ class DiscourseAPI:
                 )
             },
         )
-
-        if key and value:
-            if second_key and second_value:
-                # Three filters
-                if third_key and third_value:
+        # Tags have to be queried differently due to the way they are stored
+        if tag_value:
+            if key and value:
+                if second_key and second_value:
+                    params = (
+                        {
+                            "params": (
+                                f'{{"category_id":"{category_id}", '
+                                f'"tag_value":"{tag_value}", '
+                                f'"keyword":"{key}", "value":"{value}", '
+                                f'"second_keyword":"{second_key}", '
+                                f'"second_value":"{second_value}", '
+                                f'"limit":"{limit}", "offset":"{offset}"}}'
+                            )
+                        },
+                    )
+                else:
+                    params = (
+                        {
+                            "params": (
+                                f'{{"category_id":"{category_id}", '
+                                f'"tag_value":"{tag_value}", '
+                                f'"keyword":"{key}", "value":"{value}", '
+                                f'"limit":"{limit}", "offset":"{offset}"}}'
+                            )
+                        },
+                    )
+            else:
+                params = (
+                    {
+                        "params": (
+                            f'{{"category_id":"{category_id}", '
+                            f'"tag_value":"{tag_value}", '
+                            f'"limit":"{limit}", "offset":"{offset}"}}'
+                        )
+                    },
+                )
+        else:
+            if key and value:
+                if second_key and second_value:
                     params = (
                         {
                             "params": (
@@ -191,41 +225,25 @@ class DiscourseAPI:
                                 f'"keyword":"{key}", "value":"{value}", '
                                 f'"second_keyword":"{second_key}", '
                                 f'"second_value":"{second_value}", '
-                                f'"third_keyword":"{third_key}", '
-                                f'"third_value":"{third_value}", '
                                 f'"limit":"{limit}", "offset":"{offset}"}}'
                             )
                         },
                     )
-                # Two filters
                 else:
                     params = (
                         {
                             "params": (
                                 f'{{"category_id":"{category_id}", '
                                 f'"keyword":"{key}", "value":"{value}", '
-                                f'"second_keyword":"{second_key}", '
-                                f'"second_value":"{second_value}", '
                                 f'"limit":"{limit}", "offset":"{offset}"}}'
                             )
                         },
                     )
-            # One filter
-            else:
-                params = (
-                    {
-                        "params": (
-                            f'{{"category_id":"{category_id}", '
-                            f'"keyword":"{key}", "value":"{value}", '
-                            f'"limit":"{limit}", "offset":"{offset}"}}'
-                        )
-                    },
-                )
 
-        if limit == -1:
-            # Get all engage pages to compile list of tags
-            # last resort if you need to get all pages, not performant
-            params = ({"params": f'{{"category_id":"{category_id}"}}'},)
+            if limit == -1:
+                # Get all engage pages to compile list of tags
+                # last resort if you need to get all pages, not performant
+                params = ({"params": f'{{"category_id":"{category_id}"}}'},)
 
         response = self.session.post(
             f"{self.base_url}/admin/plugins/explorer/"

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse",
-    version="5.8.0",
+    version="5.8.1",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical/canonicalwebteam.discourse",


### PR DESCRIPTION
Updated `query_engage_page_by_param` to include filtering by two keywords/value and tags.
This allows engage pages to be filtered by up to three categories. Previously on [prod](https://ubuntu.com/engage) we only limit users to filter by one category each. 

## QA
- Go to https://ubuntu-com-14740.demos.haus/engage
- Select multiple filters from dropdown.
- Click on Apply filters button.
- See that page loads according to selected filters.