### PR TITLE
feat(Category): Check for additions or deletions of topics within a category and update cached data if needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 6.1.0 [25-01-2025]
+**Updated** Category class
+Check for additions or deletions of topics within a category and update cached data if needed
+
 ### 6.0.0 [28-01-2025]
 **Updated** Category class 
 Removed to template handling from within the Category class.

--- a/canonicalwebteam/discourse/models.py
+++ b/canonicalwebteam/discourse/models.py
@@ -122,7 +122,7 @@ class DiscourseAPI:
 
         return result["rows"]
 
-    def get_last_activity_time(self, topic_id):
+    def get_topics_last_activity_time(self, topic_id):
         """
         Uses data-explorer to the last time a specifc topic was updated
 
@@ -136,6 +136,31 @@ class DiscourseAPI:
             "Content-Type": "multipart/form-data;",
         }
         params = ({"params": (f'{{"topic_id":"{topic_id}"}} ')},)
+        response = self.session.post(
+            f"{self.base_url}/admin/plugins/explorer/"
+            f"queries/{data_explorer_id}/run",
+            headers=headers,
+            data=params[0],
+        )
+        response.raise_for_status()
+        result = response.json()
+
+        return result["rows"]
+    
+    def get_categories_last_activity_time(self, category_id):
+        """
+        Uses data-explorer to the last time a specifc topic was updated
+
+        Args:
+        - category_id [int]: The category ID
+        """
+        # See https://discourse.ubuntu.com/admin/plugins/explorer?id=123
+        data_explorer_id = 123
+        headers = {
+            "Accept": "application/json",
+            "Content-Type": "multipart/form-data;",
+        }
+        params = ({"params": (f'{{"category_id":"{category_id}"}} ')},)
         response = self.session.post(
             f"{self.base_url}/admin/plugins/explorer/"
             f"queries/{data_explorer_id}/run",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse",
-    version="6.0.0",
+    version="6.1.0",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical/canonicalwebteam.discourse",


### PR DESCRIPTION
## Done

- Creates a new [data explorer query](https://discourse.ubuntu.com/admin/plugins/explorer?id=123), that consumes a category id and return the time of the most recent deletion or addition (which ever is most recent)
- Create an api to consume call the aforementioned data explorer `get_categories_last_activity_time`
- Use this API to check if the cached list of topics is stale and update accordingly
- Some clean up of unneeded function/api calls
- Bump version to 6.1.0 and add info to changelog

## QA
