### PR TITLE
feat: Updated explorer query to filter out static case-studies on ubuntu.com/engage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 6.1.1 [12-03-2025]
+**Updated** EngagePages class
+Pass values for the provided keys, even if the values are empty or null, as they can be a filter themselves.
+
 ### 6.1.0 [25-01-2025]
 **Updated** Category class
 Check for additions or deletions of topics within a category and update cached data if needed

--- a/canonicalwebteam/discourse/models.py
+++ b/canonicalwebteam/discourse/models.py
@@ -231,11 +231,11 @@ class DiscourseAPI:
         if tag_value:
             params_dict["tag_value"] = str(tag_value)
 
-        if key and value:
+        if key:
             params_dict["keyword"] = key
             params_dict["value"] = value
 
-        if second_key and second_value:
+        if second_key:
             params_dict["second_keyword"] = second_key
             params_dict["second_value"] = second_value
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse",
-    version="6.1.0",
+    version="6.1.1",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical/canonicalwebteam.discourse",


### PR DESCRIPTION
## Done

- Updated the data explorer query
- Updated conditions for params
- u.com/engage page now doesn't show the case-studies that are statically available on canonical.com

## QA

- Go to https://ubuntu-com-14848.demos.haus/engage
- Verify the case studies are visible
- Make sure they don't include the static case-studies (case-studies that are hosted statically at canonical.com)