### PR TITLE
feat: Add function that allows injecting custom css

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ### 6.1.1 [28-04-2025]
-**Added** _handle_wide_tables
-A function that adds the class 'p-table--wide-table' to tables with 8 or more columns.
+**Added** _inject_custom_css def
+A function that finds css directives in the soup and applies to them locally.
+
+Example: `[style=p-table--wide-table]` will apply 'p-table--wide-table' as a class the the element directly after where the directive was found.
 
 ### 6.1.1 [12-03-2025]
 **Updated** EngagePages class

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 ### 6.2.0 [28-04-2025]
 **Added** _inject_custom_css def
-A function that finds css directives in the soup and applies to them locally.
-
-Example: `[style=p-table--wide-table]` will apply 'p-table--wide-table' as a class the the element directly after where the directive was found.
+A function that finds css directives (`[style=CLASSNAME]`) in the soup and applies to them to the next found element.
 
 ### 6.1.1 [12-03-2025]
 **Updated** EngagePages class

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 6.1.1 [28-04-2025]
+**Added** _handle_wide_tables
+A function that adds the class 'p-table--wide-table' to tables with 8 or more columns.
+
 ### 6.1.1 [12-03-2025]
 **Updated** EngagePages class
 Pass values for the provided keys, even if the values are empty or null, as they can be a filter themselves.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 6.1.1 [28-04-2025]
+### 6.2.0 [28-04-2025]
 **Added** _inject_custom_css def
 A function that finds css directives in the soup and applies to them locally.
 

--- a/canonicalwebteam/discourse/parsers/base_parser.py
+++ b/canonicalwebteam/discourse/parsers/base_parser.py
@@ -536,7 +536,7 @@ class BaseParser:
         soup = self._replace_polls(soup)
         soup = self._remove_trailing_numbers_from_headings(soup)
         soup = self._add_anchor_links(soup)
-        soup = self._handle_wide_tables(soup)
+        soup = self._inject_custom_css(soup)
 
         return soup
 
@@ -861,20 +861,26 @@ class BaseParser:
 
         return soup
 
-    def _handle_wide_tables(self, soup):
+    def _inject_custom_css(self, soup):
         """
-        Given HTML soup, wraps table elements with more than 8 columns
-        in a div with class 'p-wide-table'.
+        Given HTML soup, finds style identifiers and applies the given
+        class to the element directly next.
+
+        Example:
+        [style=p-table--wide-table] applies the class 'p-table--wide-table'
         """
-        for table in soup.find_all("table"):
-            first_row = table.find("tr")
-            if first_row:
-                column_count = len(first_row.find_all(["th", "td"]))
-                if column_count > 8:
-                    parent = table.parent
-                    if parent.name != "div":
-                        wrapper_div = soup.new_tag("div")
-                        table.wrap(wrapper_div)
-                    parent["class"] = "p-table--wide-table"
+        custom_css_directives = soup.find_all(string=re.compile(r"\[style=(.*?)\]"))
+
+        for css_directive in custom_css_directives:
+            match = re.search(r"\[style=(.*?)\]", css_directive)
+            if match:
+                style_class = match.group(1)
+                next_element = css_directive.find_next_sibling()
+                if next_element:
+                    if "class" in next_element.attrs:
+                        next_element["class"].append(style_class)
+                    else:
+                        next_element["class"] = [style_class]
+            css_directive.extract()
 
         return soup

--- a/canonicalwebteam/discourse/parsers/base_parser.py
+++ b/canonicalwebteam/discourse/parsers/base_parser.py
@@ -869,7 +869,9 @@ class BaseParser:
         Example:
         [style=p-table--wide-table] applies the class 'p-table--wide-table'
         """
-        custom_css_directives = soup.find_all(string=re.compile(r"\[style=(.*?)\]"))
+        custom_css_directives = soup.find_all(
+            string=re.compile(r"\[style=(.*?)\]")
+        )
 
         for css_directive in custom_css_directives:
             match = re.search(r"\[style=(.*?)\]", css_directive)

--- a/canonicalwebteam/discourse/parsers/base_parser.py
+++ b/canonicalwebteam/discourse/parsers/base_parser.py
@@ -536,6 +536,7 @@ class BaseParser:
         soup = self._replace_polls(soup)
         soup = self._remove_trailing_numbers_from_headings(soup)
         soup = self._add_anchor_links(soup)
+        soup = self._handle_wide_tables(soup)
 
         return soup
 
@@ -857,5 +858,23 @@ class BaseParser:
                 anchor["class"] = "p-link--anchor-heading"
                 heading.clear()
                 heading.append(anchor)
+
+        return soup
+
+    def _handle_wide_tables(self, soup):
+        """
+        Given HTML soup, wraps table elements with more than 8 columns
+        in a div with class 'p-wide-table'.
+        """
+        for table in soup.find_all("table"):
+            first_row = table.find("tr")
+            if first_row:
+                column_count = len(first_row.find_all(["th", "td"]))
+                if column_count > 8:
+                    parent = table.parent
+                    if parent.name != "div":
+                        wrapper_div = soup.new_tag("div")
+                        table.wrap(wrapper_div)
+                    parent["class"] = "p-table--wide-table"
 
         return soup

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse",
-    version="6.1.1",
+    version="6.1.2",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical/canonicalwebteam.discourse",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse",
-    version="6.1.2",
+    version="6.2.0",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical/canonicalwebteam.discourse",


### PR DESCRIPTION
## Done

**Added** _inject_custom_css def
A function that finds css directives in the soup and applies to them to the next found element.

Example: `[style=p-table--wide-table]` will apply 'p-table--wide-table' as a class the the element directly after where the directive was found.

## QA

- Go to this [Discourse post](https://discourse.ubuntu.com/t/test-topic/59821) and find the table with the string '[style=p-table--wide-table]' above it
- Find the corresponding table in [the demo](https://ubuntu-com-15050.demos.haus/security/vulnerabilities/test-topic). See the string, '[style=p-table--wide-table]', has been removed
- Inspect the table element and see it is wrapped in a div with the class 'p-table--wide-table'

## Issue

Fixes https://warthogs.atlassian.net/browse/WD-20353