### PR TITLE
Create Event and EventParser classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### 7.0.0 [18-06-2025]
+**Added** Events class
+- Created a new class to handle events from 'Discourse Calender (and events)' API
+**Added** EventsParser class
+- Created a new parser to process the events retrieve by the Events class
+**Updated** check_for_category_updates & check_for_topic_updates
+- Moved from Category into DiscourseAPI 
+
 ### 6.4.0 [12-06-2025]
 **Updated** Discourse API
 - Created a new API to query upcoming events in a category

--- a/canonicalwebteam/discourse/__init__.py
+++ b/canonicalwebteam/discourse/__init__.py
@@ -3,10 +3,12 @@ from canonicalwebteam.discourse.app import (  # noqa
     EngagePages,  # noqa
     Tutorials,  # noqa
     Category,  # noqa
+    Events,  # noqa
 )
 from canonicalwebteam.discourse.models import DiscourseAPI  # noqa
 from canonicalwebteam.discourse.parsers import (  # noqa
     DocParser,  # noqa
     TutorialParser,  # noqa
     CategoryParser,  # noqa
+    EventsParser,  # noqa
 )

--- a/canonicalwebteam/discourse/app.py
+++ b/canonicalwebteam/discourse/app.py
@@ -834,25 +834,24 @@ class Events:
         )
 
         if self.all_events is None or updated:
-            self.all_events = (
-                self.parser.api.get_events()["events"]
-            )
+            self.all_events = self.parser.api.get_events()["events"]
             self.events_last_updated = updated_at
 
         return self.all_events
 
     def get_featured_events(self, target_tag="featured-event") -> list:
         """
-        Fetches all featured events from the category across all pages
+        Fetches events that are marked with a specific tag.
 
         :param target_tag: Tag to filter featured events by.
-        """ 
-        featured_events_ids = self.parser.api.get_topics_by_tag(
-            target_tag)["grouped_search_result"]["post_ids"]
+        """
+        featured_events_ids = self.parser.api.get_topics_by_tag(target_tag)[
+            "grouped_search_result"
+        ]["post_ids"]
         all_events = self.get_events()
 
         self.featured_events = self.parser.parse_featured_events(
             all_events, featured_events_ids
         )
-        
+
         return self.featured_events

--- a/canonicalwebteam/discourse/app.py
+++ b/canonicalwebteam/discourse/app.py
@@ -766,8 +766,8 @@ class Category:
         :param data_name: Name of the data table
         """
         try:
-            updated, updated_at = self._check_for_topic_updates(
-                self.parser.index_topic_id
+            updated, updated_at = self.parser.api.check_for_topic_updates(
+                self.parser.index_topic_id, self.index_last_updated
             )
 
             if self.category_index_metadata is None or updated:
@@ -788,8 +788,8 @@ class Category:
         Exposes an API to query all topics in a category
         """
         try:
-            updated, updated_at = self._check_for_category_updates(
-                self.category_id
+            updated, updated_at = self.parser.api.check_for_category_updates(
+                self.category_id, self.category_last_updated
             )
 
             if self.category_topics is None or updated:

--- a/canonicalwebteam/discourse/models.py
+++ b/canonicalwebteam/discourse/models.py
@@ -210,6 +210,49 @@ class DiscourseAPI:
 
         return result["rows"]
 
+    def check_for_topic_updates(self, topic_id, last_updated=None) -> tuple:
+        """
+        Check if a topic has been updated since the last_updated timestamp
+
+        Args:
+        - topic_id (int): The topic ID
+        - last_updated (timestamp): The last time the topic was updated
+
+        Returns:
+        - tuple: (bool, timestamp) - whether there are updates and the most
+        recent update time
+        """
+        most_recent_update = self.get_topics_last_activity_time(topic_id)[0][1]
+
+        if last_updated and most_recent_update > last_updated:
+            return True, most_recent_update
+        else:
+            return False, most_recent_update
+
+    def check_for_category_updates(
+        self, category_id, last_updated=None
+    ) -> tuple:
+        """
+        Check if the category has had topics added or removed since the
+        last_updated timestamp
+
+        Args:
+        - category_id (int): The category ID
+        - last_updated (timestamp): The last time the category was updated
+
+        Returns:
+        - tuple: (bool, timestamp) - whether there are updates and the most
+        recent update time
+        """
+        most_recent_update = self.get_categories_last_activity_time(
+            category_id
+        )[0][1]
+
+        if last_updated and most_recent_update > last_updated:
+            return True, most_recent_update
+        else:
+            return False, most_recent_update
+
     def get_engage_pages_by_param(
         self,
         category_id,

--- a/canonicalwebteam/discourse/models.py
+++ b/canonicalwebteam/discourse/models.py
@@ -321,7 +321,7 @@ class DiscourseAPI:
 
         To get an engage page by path:
         key = path
-        value = /engage/nfv-management-and-orchestration-
+        value = /engage/nfv-management-and-orchestration-charmed-open-source-mano
 
         Args:
         - limit [int]: 50 by default, also set in data explorer

--- a/canonicalwebteam/discourse/models.py
+++ b/canonicalwebteam/discourse/models.py
@@ -321,7 +321,8 @@ class DiscourseAPI:
 
         To get an engage page by path:
         key = path
-        value = /engage/nfv-management-and-orchestration-charmed-open-source-mano
+        value = /engage/nfv-management-and-orchestration-charmed-open
+        -source-mano
 
         Args:
         - limit [int]: 50 by default, also set in data explorer

--- a/canonicalwebteam/discourse/parsers/__init__.py
+++ b/canonicalwebteam/discourse/parsers/__init__.py
@@ -7,3 +7,6 @@ from canonicalwebteam.discourse.parsers.tutorials import (  # noqa
 from canonicalwebteam.discourse.parsers.category import (  # noqa
     CategoryParser,  # noqa
 )
+from canonicalwebteam.discourse.parsers.events import (  # noqa
+    EventsParser,  # noqa
+)

--- a/canonicalwebteam/discourse/parsers/events.py
+++ b/canonicalwebteam/discourse/parsers/events.py
@@ -1,0 +1,22 @@
+class EventsParser:
+    """
+    Parses featured events from a list of all events.
+    """
+
+    def __init__(self, api):
+        self.api = api
+
+    def parse_featured_events(self, all_events, featured_events_ids) -> list:
+        """
+        Sorts through all events and returns only those that are featured.
+
+        :return: List of events objects that are featured events
+        """
+        featured_events_ids = set(featured_events_ids)
+        featured_events = []
+
+        for event in all_events:
+            if event["id"] in featured_events_ids:
+                featured_events.append(event)
+
+        return featured_events

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse",
-    version="6.3.0",
+    version="7.0.0",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical/canonicalwebteam.discourse",

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -503,7 +503,9 @@ class TestEventsParser(unittest.TestCase):
         all_events = []
         featured_events_ids = []
 
-        result = self.events_parser.parse_featured_events(all_events, featured_events_ids)
+        result = self.events_parser.parse_featured_events(
+            all_events, featured_events_ids
+        )
 
         self.assertEqual(result, [])
         self.assertEqual(len(result), 0)
@@ -517,7 +519,9 @@ class TestEventsParser(unittest.TestCase):
         ]
         featured_events_ids = [4, 5, 6]
 
-        result = self.events_parser.parse_featured_events(all_events, featured_events_ids)
+        result = self.events_parser.parse_featured_events(
+            all_events, featured_events_ids
+        )
 
         self.assertEqual(result, [])
         self.assertEqual(len(result), 0)
@@ -532,7 +536,9 @@ class TestEventsParser(unittest.TestCase):
         ]
         featured_events_ids = [2, 4]
 
-        result = self.events_parser.parse_featured_events(all_events, featured_events_ids)
+        result = self.events_parser.parse_featured_events(
+            all_events, featured_events_ids
+        )
 
         self.assertEqual(len(result), 2)
         self.assertEqual(result[0]["id"], 2)
@@ -541,7 +547,9 @@ class TestEventsParser(unittest.TestCase):
         self.assertEqual(result[1]["title"], "Event 4")
 
     def test_parse_featured_events_duplicate_ids(self):
-        """Test parsing featured events with duplicate IDs in featured_events_ids."""
+        """
+        Test parsing featured events with duplicate IDs in featured_events_ids.
+        """
         all_events = [
             {"id": 1, "title": "Event 1"},
             {"id": 2, "title": "Event 2"},
@@ -549,7 +557,9 @@ class TestEventsParser(unittest.TestCase):
         ]
         featured_events_ids = [1, 1, 2, 2, 3]
 
-        result = self.events_parser.parse_featured_events(all_events, featured_events_ids)
+        result = self.events_parser.parse_featured_events(
+            all_events, featured_events_ids
+        )
 
         # Expecting no duplicates
         self.assertEqual(len(result), 3)


### PR DESCRIPTION
## Done

refactor: Move update checks to model.py
feat: Create Event and EventParser classes to fetch and parse events from Discourse Calendar plugin
chore: Update readme and changelog

## QA

- Open the [demo](https://ubuntu-com-15193.demos.haus/community)
- You should see one result with an id '58898' and the associated event data
- Visit the [post](https://discourse.ubuntu.com/t/ubuntu-at-guadec-2025/58898) of the one result. Check it is an event, it hasn't passed, and it has the tag 'events'