### PR TITLE
Normalize case and whitespace in engage page tags retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 6.3.0 [02-07-2025]
+**Added** EngagePages class
+Remove duplicated tags from the list of tags returned from `get_engage_pages_tags`
+
 ### 6.2.0 [28-04-2025]
 **Added** _inject_custom_css def
 A function that finds css directives (`[style=CLASSNAME]`) in the soup and applies to them to the next found element.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### 6.3.0 [02-07-2025]
-**Added** EngagePages class
+**Updated** EngagePages class
 Remove duplicated tags from the list of tags returned from `get_engage_pages_tags`
 
 ### 6.2.0 [28-04-2025]

--- a/canonicalwebteam/discourse/app.py
+++ b/canonicalwebteam/discourse/app.py
@@ -405,7 +405,11 @@ class EngagePages(BaseParser):
                 try:
                     topics_index = self.parse_topics(topic)
                     if "tags" in topics_index:
-                        tags = tags.union(set(topics_index["tags"].split(",")))
+                        raw_tags = topics_index["tags"].split(",")
+                        cleaned_tags = {
+                            tag.strip().lower() for tag in raw_tags
+                        }
+                        tags.update(cleaned_tags)
                 except MetadataError:
                     continue
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse",
-    version="6.2.0",
+    version="6.3.0",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical/canonicalwebteam.discourse",


### PR DESCRIPTION
## Done
Remove duplicate tags by normalizing case and whitespace in the `get_engage_pages_tags` function. This enhancement improves the consistency and accuracy of the tags returned. Tags added to engage pages happen to be inconsistent in terms of casing, for example, 'cloud' and 'Cloud', this causes the tags to be returned as duplicates but different in casing.

## QA
- Visit [demo](https://ubuntu-com-15299.demos.haus/engage)
- Verify that there are no duplicate tags in the filter select dropdown

### Fixes 
https://warthogs.atlassian.net/browse/WD-22509