### PR TITLE
Update EngagePages tags filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 7.1.0 [17-11-2025]
+**Updated** EngagePages class
+- Support optional `value` in `get_engage_pages_tags` to return tags for a specific engage page type
+**Fixed** DiscourseAPI filtering
+- Only include `keyword` and `value` when both are provided; same for `second_keyword`/`second_value` to avoid sending `None` to the Data Explorer API
+
 ### 7.0.0 [01-07-2025]
 **Added** Events class
 - Created a new class to handle events from 'Discourse Calender (and events)' API

--- a/canonicalwebteam/discourse/app.py
+++ b/canonicalwebteam/discourse/app.py
@@ -390,14 +390,21 @@ class EngagePages(BaseParser):
 
         return metadata
 
-    def get_engage_pages_tags(self):
+    def get_engage_pages_tags(self, value=None):
         """
-        Get all tags in all engage pages
-        for the dropdown filter
+        Get all tags in {value} engage pages
+        for the dropdown filter. If no value is
+        passed, it fetches all engage pages tags
         """
-        list_topics = self.api.get_engage_pages_by_param(
-            category_id=self.category_id, limit=-1
-        )
+        params = {
+            "category_id": self.category_id,
+            "limit": -1,
+        }
+        if value is not None and isinstance(value, str):
+            params["key"] = "type"
+            params["value"] = value
+
+        list_topics = self.api.get_engage_pages_by_param(**params)
         tags = set()
         for topic in list_topics:
             if topic[6] not in self.exclude_topics:

--- a/canonicalwebteam/discourse/models.py
+++ b/canonicalwebteam/discourse/models.py
@@ -348,11 +348,11 @@ class DiscourseAPI:
         if tag_value:
             params_dict["tag_value"] = str(tag_value)
 
-        if key:
+        if key and value:
             params_dict["keyword"] = key
             params_dict["value"] = value
 
-        if second_key:
+        if second_key and second_value:
             params_dict["second_keyword"] = second_key
             params_dict["second_value"] = second_value
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse",
-    version="7.0.0",
+    version="7.1.0",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical/canonicalwebteam.discourse",


### PR DESCRIPTION
## Done
- add optional value parameter to `get_engage_pages_tags` for type-specific filtering
- fix DiscourseAPI filtering to only include keyword/value pairs when both are provided

### Impact
- Correctly filtered results when a value is not provided: filters are skipped rather than sending None , reducing API errors and unexpected results.
- More precise tag lists for UI dropdowns when filtering by engage page type.

## QA
- Check out [/case-study](https://canonical-com-2059.demos.haus/case-study)
- Select Anjuna from the tags and apply filter (https://canonical-com-2059.demos.haus/case-study?tag=anjuna)
- Check that posts appear
- Select security from the tags and apply fitler
- Check that posts appear

Compare that to production
- Check out [/case-study](https://canonical.com/case-study)
- Apply `anjuna` tag filter (https://canonical.com/case-study?tag=anjuna)
- See that no posts appear
- Select `english` from the language filter while having `anjuna` tag applies and see that posts appear (https://canonical.com/case-study?tag=anjuna&language=en)


## Tickets
https://warthogs.atlassian.net/browse/WD-31245
https://warthogs.atlassian.net/browse/WD-21422

## Screenshots
### Before
<img width="1730" height="878" alt="image" src="https://github.com/user-attachments/assets/b3b2f412-8170-4a08-9353-efec4bcef8c8" />


### After
<img width="1656" height="1460" alt="image" src="https://github.com/user-attachments/assets/2e473c02-d4b6-459f-8000-d74e5df06ab4" />

