### PR TITLE
feat: Add better error handling for missing api key and username

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 7.1.1 [01-07-2025]
+**Added**
+- Better error handling when api key and username is missing
+
 ### 7.1.0 [17-11-2025]
 **Updated** EngagePages class
 - Support optional `value` in `get_engage_pages_tags` to return tags for a specific engage page type

--- a/canonicalwebteam/discourse/models.py
+++ b/canonicalwebteam/discourse/models.py
@@ -27,12 +27,26 @@ class DiscourseAPI:
         self.base_url = base_url.rstrip("/")
         self.session = session
         self.get_topics_query_id = get_topics_query_id
+        self.api_key = api_key
+        self.api_username = api_username
 
         if api_key and api_username:
             self.session.headers = {
                 "Api-Key": api_key,
                 "Api-Username": api_username,
             }
+
+    def _require_authentication(self):
+        """
+        Check if API credentials are available and raise an error if not.
+        This should be called before accessing authenticated endpoints.
+        a.k.a. Data Explorer endpoints.
+        """
+        if not self.api_key or not self.api_username:
+            raise ValueError(
+                "API authentication required: API key and username "
+                "are required to access this endpoint"
+            )
 
     def __del__(self):
         self.session.close()
@@ -54,6 +68,8 @@ class DiscourseAPI:
         we are using it to obtain multiple Tutorials content without
         doing multiple API calls.
         """
+        self._require_authentication()
+
         headers = {
             "Accept": "application/json",
             "Content-Type": "multipart/form-data;",
@@ -167,6 +183,8 @@ class DiscourseAPI:
         - limit [int]: 100 by default, also set in data explorer
         - offset [int]: 0 by default (first page)
         """
+        self._require_authentication()
+
         # See https://discourse.ubuntu.com/admin/plugins/explorer?id=89
         data_explorer_id = 89
         headers = {
@@ -203,6 +221,8 @@ class DiscourseAPI:
         Args:
         - topic_id [int]: The topic ID
         """
+        self._require_authentication()
+
         # See https://discourse.ubuntu.com/admin/plugins/explorer?id=122
         data_explorer_id = 122
         headers = {
@@ -228,6 +248,8 @@ class DiscourseAPI:
         Args:
         - category_id [int]: The category ID
         """
+        self._require_authentication()
+
         # See https://discourse.ubuntu.com/admin/plugins/explorer?id=123
         data_explorer_id = 123
         headers = {
@@ -331,6 +353,8 @@ class DiscourseAPI:
         - limit [int]: 50 by default, also set in data explorer
         - offset [int]: 0 by default (first page)
         """
+        self._require_authentication()
+
         headers = {
             "Accept": "application/json",
             "Content-Type": "multipart/form-data;",
@@ -392,6 +416,8 @@ class DiscourseAPI:
         - limit [int]: 50 by default, also set in data explorer
         - offset [int]: 0 by default (first page)
         """
+        self._require_authentication()
+
         headers = {
             "Accept": "application/json",
             "Content-Type": "multipart/form-data;",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse",
-    version="7.1.0",
+    version="7.1.1",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical/canonicalwebteam.discourse",

--- a/tests/test_engage_pages.py
+++ b/tests/test_engage_pages.py
@@ -28,6 +28,8 @@ class TestDiscourseAPI(VCRTestCase):
         self.discourse_api = DiscourseAPI(
             base_url="https://discourse.ubuntu.com/",
             session=session,
+            api_key="fake-api-key",
+            api_username="fake-username",
         )
         self.engage_pages = EngagePages(
             category_id=51,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -26,6 +26,11 @@ class TestDiscourseAPI(unittest.TestCase):
         self.assertEqual(topic["id"], 34)
         self.assertEqual(topic["title"], "An index page")
 
+    def test_require_authentication_raises_error_without_credentials(self):
+        with self.assertRaises(ValueError) as context:
+            self.api._require_authentication()
+        self.assertIn("API authentication required", str(context.exception))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Done

feat: Add better error handling for missing api key and username

## QA

- Check out [this branch](https://github.com/canonical/ubuntu.com/pull/15857) locally
- Comment out any discourse api keys
- Run the project
- See there are no errors
- See the following exception is raised:
```
ValueError: API authentication required: both api_key and api_username must be provided to access this endpoint
```

## Issue

Fixes: https://warthogs.atlassian.net/browse/WD-2024