### PR TITLE
feat: handle sentry_sdk integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 7.2.0 [04-12-2025]
+**Added**
+- Handle apps with both the new (sentry_sdk) and old (raven) Sentry integrations 
+
 ### 7.1.1 [04-12-2025]
 **Added**
 - Better error handling when api key and username is missing

--- a/canonicalwebteam/discourse/exceptions.py
+++ b/canonicalwebteam/discourse/exceptions.py
@@ -9,11 +9,11 @@ except ImportError:
 
 def _capture_sentry_message(message):
     """
-    Handle apps with both the new and old Sentry integrations, 
+    Handle apps with both the new and old Sentry integrations,
     as well as apps without Sentry.
 
     - New style: ``sentry_sdk`` (Flask 2+, sentry-sdk package)
-    - Old style: ``flask.current_app.extensions["sentry"]`` (raven/Flask-Sentry)
+    - Old style: ``flask.current_app.extensions["sentry"]`` (raven)
 
     If neither is configured the message is silently dropped so that apps
     without Sentry don't crash.
@@ -66,7 +66,9 @@ class MetadataError(Exception):
 
     def __init__(self, *args: object) -> None:
         error_message = args[0]
-        _capture_sentry_message(f"Engage pages metadata error: {error_message}")
+        _capture_sentry_message(
+            f"Engage pages metadata error: {error_message}"
+        )
         pass
 
 
@@ -94,7 +96,9 @@ class DataExplorerError(Exception):
 
     def __init__(self, *args: object) -> None:
         error_message = args[0]
-        _capture_sentry_message(f"Engage pages Data Explorer error {error_message}")
+        _capture_sentry_message(
+            f"Engage pages Data Explorer error {error_message}"
+        )
         pass
 
 
@@ -107,7 +111,9 @@ class DiscourseEventsError(Exception):
 
     def __init__(self, *args: object) -> None:
         error_message = args[0]
-        _capture_sentry_message(f"Discourse event plugin error {error_message}")
+        _capture_sentry_message(
+            f"Discourse event plugin error {error_message}"
+        )
         pass
 
 

--- a/canonicalwebteam/discourse/exceptions.py
+++ b/canonicalwebteam/discourse/exceptions.py
@@ -1,5 +1,32 @@
 import flask
 
+# Initialize sentry_sdk if available
+try:
+    import sentry_sdk as _sentry_sdk
+except ImportError:
+    _sentry_sdk = None
+
+
+def _capture_sentry_message(message):
+    """
+    Handle apps with both the new and old Sentry integrations, 
+    as well as apps without Sentry.
+
+    - New style: ``sentry_sdk`` (Flask 2+, sentry-sdk package)
+    - Old style: ``flask.current_app.extensions["sentry"]`` (raven/Flask-Sentry)
+
+    If neither is configured the message is silently dropped so that apps
+    without Sentry don't crash.
+    """
+    if _sentry_sdk is not None and _sentry_sdk.is_initialized():
+        _sentry_sdk.capture_message(message)
+        return
+
+    try:
+        flask.current_app.extensions["sentry"].captureMessage(message)
+    except (RuntimeError, KeyError, AttributeError):
+        pass
+
 
 class PathNotFoundError(Exception):
     """
@@ -39,9 +66,7 @@ class MetadataError(Exception):
 
     def __init__(self, *args: object) -> None:
         error_message = args[0]
-        flask.current_app.extensions["sentry"].captureMessage(
-            f"Engage pages metadata error: {error_message}"
-        )
+        _capture_sentry_message(f"Engage pages metadata error: {error_message}")
         pass
 
 
@@ -55,9 +80,7 @@ class MarkdownError(Exception):
 
     def __init__(self, *args: object) -> None:
         error_message = args[0]
-        flask.current_app.extensions["sentry"].captureMessage(
-            f"Engage pages markdown error {error_message}"
-        )
+        _capture_sentry_message(f"Engage pages markdown error {error_message}")
         pass
 
 
@@ -71,9 +94,7 @@ class DataExplorerError(Exception):
 
     def __init__(self, *args: object) -> None:
         error_message = args[0]
-        flask.current_app.extensions["sentry"].captureMessage(
-            f"Engage pages Data Explorer error {error_message}"
-        )
+        _capture_sentry_message(f"Engage pages Data Explorer error {error_message}")
         pass
 
 
@@ -86,9 +107,7 @@ class DiscourseEventsError(Exception):
 
     def __init__(self, *args: object) -> None:
         error_message = args[0]
-        flask.current_app.extensions["sentry"].captureMessage(
-            f"Discourse event plugin error {error_message}"
-        )
+        _capture_sentry_message(f"Discourse event plugin error {error_message}")
         pass
 
 

--- a/canonicalwebteam/discourse/parsers/base_parser.py
+++ b/canonicalwebteam/discourse/parsers/base_parser.py
@@ -5,6 +5,7 @@ import os
 import re
 import flask
 from urllib.parse import urlparse, urlunparse
+from canonicalwebteam.discourse.exceptions import _capture_sentry_message
 
 # Packages
 import dateutil.parser
@@ -34,7 +35,7 @@ class MissingContentError(ParsingError):
     def __init__(self, error):
         super().__init__(error)
 
-        flask.current_app.extensions["sentry"].captureMessage(error)
+        _capture_sentry_message(error)
 
 
 class BaseParser:

--- a/canonicalwebteam/discourse/parsers/base_parser.py
+++ b/canonicalwebteam/discourse/parsers/base_parser.py
@@ -3,7 +3,6 @@ import copy
 from functools import cached_property
 import os
 import re
-import flask
 from urllib.parse import urlparse, urlunparse
 from canonicalwebteam.discourse.exceptions import _capture_sentry_message
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse",
-    version="7.1.1",
+    version="7.2.0",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical/canonicalwebteam.discourse",

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ commands =
 description = Lint Python
 deps =
     flake8
-    black
+    black==25.1.0
 commands =
     flake8 --extend-ignore=E203 canonicalwebteam tests setup.py
     black --line-length 79 --check canonicalwebteam tests setup.py
@@ -25,6 +25,6 @@ commands =
 [testenv:format]
 description = Format Python
 deps =
-    black
+    black==25.1.0
 commands =
     black --line-length 79 canonicalwebteam tests setup.py


### PR DESCRIPTION
## Done

- Adds a helper function `def _capture_sentry_message` that checks if `sentry_sdk` is available and uses it if it is. If not, it falls back to raven based sentry login. This allows pre and post Flask 2 applications to work with the module

## QA
See that https://ubuntu-com-16114.demos.haus/engage loads ([PR](https://github.com/canonical/ubuntu.com/pull/16114))

## Fixes
https://warthogs.atlassian.net/browse/WD-34688