### PR TITLE
Parse custom blocks

### DIFF
--- a/canonicalwebteam/discourse/app.py
+++ b/canonicalwebteam/discourse/app.py
@@ -9,7 +9,7 @@ from canonicalwebteam.discourse.exceptions import (
     MarkdownError,
 )
 
-from canonicalwebteam.discourse.parsers.base_parser import BaseParser
+from canonicalwebteam.discourse.parsers.base_parser import BaseParser, LANGUAGE_MAP
 import dateutil.parser
 from bs4 import BeautifulSoup, element
 from datetime import datetime
@@ -445,6 +445,10 @@ class EngagePages(BaseParser):
         soup = self._replace_notifications(soup)
         soup = self._replace_notes_to_editors(soup)
         soup = self._replace_polls(soup)
+        soup = self._replace_lists(soup)
+        soup = self._replace_blockquotes_block(soup)
+        soup = self._replace_highlights_block(soup)
+        soup = self._replace_image_block(soup)
 
         return soup
 
@@ -460,6 +464,7 @@ class EngagePages(BaseParser):
         - topics: list
         """
 
+        print("PARSING TOPIC", topic[6])
         # Construct path using slug and id
         topic_path = f"{self.api.base_url}/t/{topic[7]}/{topic[6]}"
 
@@ -469,6 +474,7 @@ class EngagePages(BaseParser):
 
         topic_soup = BeautifulSoup(topic[0], features="html.parser")
 
+        print(topic_soup)
         metadata = {}
 
         # Does metadata table exist?
@@ -559,6 +565,12 @@ class EngagePages(BaseParser):
                             f" {error} for {topic_path}"
                         )
                         raise MetadataError(error_message)
+
+            if "language" in metadata:
+                metadata["language"] = LANGUAGE_MAP.get(
+                    str(metadata["language"]).strip().lower(),
+                    metadata["language"],
+                )
 
             # Further metadata checks
             try:

--- a/canonicalwebteam/discourse/app.py
+++ b/canonicalwebteam/discourse/app.py
@@ -9,7 +9,10 @@ from canonicalwebteam.discourse.exceptions import (
     MarkdownError,
 )
 
-from canonicalwebteam.discourse.parsers.base_parser import BaseParser, LANGUAGE_MAP
+from canonicalwebteam.discourse.parsers.base_parser import (
+    BaseParser,
+    LANGUAGE_MAP,
+)
 import dateutil.parser
 from bs4 import BeautifulSoup, element
 from datetime import datetime
@@ -466,7 +469,6 @@ class EngagePages(BaseParser):
         - topics: list
         """
 
-        print("PARSING TOPIC", topic[6])
         # Construct path using slug and id
         topic_path = f"{self.api.base_url}/t/{topic[7]}/{topic[6]}"
 
@@ -476,7 +478,6 @@ class EngagePages(BaseParser):
 
         topic_soup = BeautifulSoup(topic[0], features="html.parser")
 
-        print(topic_soup)
         metadata = {}
 
         # Does metadata table exist?

--- a/canonicalwebteam/discourse/app.py
+++ b/canonicalwebteam/discourse/app.py
@@ -449,6 +449,8 @@ class EngagePages(BaseParser):
         soup = self._replace_blockquotes_block(soup)
         soup = self._replace_highlights_block(soup)
         soup = self._replace_image_block(soup)
+        soup = self._replace_standard_table_block(soup)
+        soup = self._replace_checklist_paragraph(soup)
 
         return soup
 

--- a/canonicalwebteam/discourse/exceptions.py
+++ b/canonicalwebteam/discourse/exceptions.py
@@ -9,11 +9,12 @@ except ImportError:
 
 def _capture_sentry_message(message):
     """
-    Handle apps with both the new and old Sentry integrations, 
+    Handle apps with both the new and old Sentry integrations,
     as well as apps without Sentry.
 
     - New style: ``sentry_sdk`` (Flask 2+, sentry-sdk package)
-    - Old style: ``flask.current_app.extensions["sentry"]`` (raven/Flask-Sentry)
+    - Old style: ``flask.current_app.extensions["sentry"]``
+    (raven/Flask-Sentry)
 
     If neither is configured the message is silently dropped so that apps
     without Sentry don't crash.
@@ -66,7 +67,9 @@ class MetadataError(Exception):
 
     def __init__(self, *args: object) -> None:
         error_message = args[0]
-        _capture_sentry_message(f"Engage pages metadata error: {error_message}")
+        _capture_sentry_message(
+            f"Engage pages metadata error: {error_message}"
+        )
         pass
 
 
@@ -94,7 +97,9 @@ class DataExplorerError(Exception):
 
     def __init__(self, *args: object) -> None:
         error_message = args[0]
-        _capture_sentry_message(f"Engage pages Data Explorer error {error_message}")
+        _capture_sentry_message(
+            f"Engage pages Data Explorer error {error_message}"
+        )
         pass
 
 
@@ -107,7 +112,9 @@ class DiscourseEventsError(Exception):
 
     def __init__(self, *args: object) -> None:
         error_message = args[0]
-        _capture_sentry_message(f"Discourse event plugin error {error_message}")
+        _capture_sentry_message(
+            f"Discourse event plugin error {error_message}"
+        )
         pass
 
 

--- a/canonicalwebteam/discourse/exceptions.py
+++ b/canonicalwebteam/discourse/exceptions.py
@@ -14,7 +14,7 @@ def _capture_sentry_message(message):
 
     - New style: ``sentry_sdk`` (Flask 2+, sentry-sdk package)
     - Old style: ``flask.current_app.extensions["sentry"]``
-    (raven/Flask-Sentry)
+      (raven/Flask-Sentry)
 
     If neither is configured the message is silently dropped so that apps
     without Sentry don't crash.

--- a/canonicalwebteam/discourse/parsers/base_parser.py
+++ b/canonicalwebteam/discourse/parsers/base_parser.py
@@ -11,7 +11,7 @@ from canonicalwebteam.discourse.exceptions import _capture_sentry_message
 import dateutil.parser
 import humanize
 import validators
-from bs4 import BeautifulSoup, NavigableString
+from bs4 import BeautifulSoup, NavigableString, Tag
 from canonicalwebteam.discourse.exceptions import (
     PathNotFoundError,
     RedirectFoundError,
@@ -25,6 +25,20 @@ TOPIC_URL_MATCH = re.compile(
 )
 
 HEADER_REGEX = re.compile("^h[1-6]$")
+
+# Mapping of human readable language names to language codes
+LANGUAGE_MAP = {
+    "english": "en",
+    "chinese (traditional)": "zh-TW",
+    "deutsche": "de",
+    "español": "es",
+    "français": "fr",
+    "italiano": "it",
+    "korean": "kr",
+    "português": "pt",
+    "russian": "ru",
+    "türkçe": "tr",
+}
 
 
 class ParsingError(Exception):
@@ -532,6 +546,9 @@ class BaseParser:
 
         soup = self._replace_notifications(soup)
         soup = self._replace_notes_to_editors(soup)
+        soup = self._replace_blockquotes_block(soup)
+        soup = self._replace_highlights_block(soup)
+        soup = self._replace_image_block(soup)
         soup = self._replace_image_src(soup)
         soup = self._replace_links(soup)
         soup = self._replace_polls(soup)
@@ -843,6 +860,286 @@ class BaseParser:
                     # Update any links to this heading within the document
                     for link in soup.find_all("a", href=f"#{anchor_id}"):
                         link["href"] = f"#{new_id}"
+
+        return soup
+
+    def _replace_lists(self, soup):
+        """
+        Given a HTML soup, find all unordered and ordered lists and add
+        the following classes to them:
+        ```
+        <ul class="p-list--divided">
+            <li class="p-list__item has-bullet">...</li>
+            OR
+            <li class="p-list__item is-ticked">...</li>
+            ...
+        </ul>
+        <ol class="p-list--divided">
+            <li class="p-list__item">...</li>
+            ...
+        </ol>
+        ```
+        These use styles from https://vanillaframework.io/docs/patterns/lists
+        """
+        for ul in soup.find_all("ul"):
+            if "p-list--divided" in ul.get("class", []):
+                continue
+            ul["class"] = ul.get("class", []) + ["p-list--divided"]
+            for li in ul.find_all("li", recursive=False):
+                if "p-list__item" in li.get("class", []):
+                    continue
+                checkbox = li.find(
+                    "span", class_=lambda c: c and "chcklst-box" in c and "checked" in c
+                )
+                if checkbox:
+                    checkbox.decompose()
+                    li["class"] = li.get("class", []) + [
+                        "p-list__item",
+                        "is-ticked",
+                    ]
+                else:
+                    li["class"] = li.get("class", []) + [
+                        "p-list__item",
+                        "has-bullet",
+                    ]
+
+        for ol in soup.find_all("ol"):
+            if "p-list--divided" in ol.get("class", []):
+                continue
+            ol["class"] = ol.get("class", []) + ["p-list--divided"]
+            for li in ol.find_all("li", recursive=False):
+                if "p-list__item" in li.get("class", []):
+                    continue
+                li["class"] = li.get("class", []) + ["p-list__item"]
+
+        return soup
+
+    def _replace_blockquotes_block(self, soup):
+        """
+        Given HTML soup, find quote blocks wrapped with the ::: marker and
+        transform them into styled quote components.
+
+        Input:
+        <p>::: quote-block</p>
+        <blockquote>
+            <p>"Quote text."</p>
+            <p>— <strong>Author</strong>, <em>Organisation</em></p>
+        </blockquote>
+        <p>:::</p>
+
+        Output:
+        <p class="p-heading--2"><i>"Quote text."</i></p>
+        <strong>Author</strong>
+        <em>Organisation</em>
+
+        The citation paragraph (second <p> inside the blockquote) is optional,
+        and may contain any combination of <strong> (name) and <em>
+        (organisation).
+        """
+        for open_marker in soup.find_all("p", string="::: quote-block"):
+            blockquote = open_marker.find_next_sibling("blockquote")
+            close_marker = open_marker.find_next_sibling(
+                "p", string=":::"
+            )
+
+            if not blockquote or not close_marker:
+                continue
+
+            paragraphs = blockquote.find_all("p", recursive=False)
+            if not paragraphs:
+                continue
+
+            # First paragraph holds the quote text
+            quote_text = paragraphs[0].get_text(strip=True)
+            if not quote_text:
+                continue
+
+            # Build the quote paragraph
+            quote_p = soup.new_tag("p")
+            quote_p["class"] = ["p-heading--4"]
+            quote_i = soup.new_tag("i")
+            quote_i.string = quote_text
+            quote_p.append(quote_i)
+
+            # Collect citation elements (<strong> and/or <em>) from the
+            # optional second paragraph, preserving document order
+            citation_elements = []
+            if len(paragraphs) > 1:
+                for tag in paragraphs[1].find_all(["strong", "em"]):
+                    citation_elements.append(copy.copy(tag))
+
+            # Replace the entire wrapper (open marker, blockquote, close
+            # marker) with the new markup
+            open_marker.replace_with(quote_p)
+            blockquote.decompose()
+            close_marker.decompose()
+
+            # Insert citation elements after the quote, preserving order.
+            # <strong> is wrapped in a <p> (with u-no-margin--bottom when
+            # followed by a second element); <em> becomes a plain <p
+            # class="u-text--muted"> containing just the text.
+            insert_after = quote_p
+            for index, element in enumerate(citation_elements):
+                citation_p = soup.new_tag("p")
+                if element.name == "em":
+                    citation_p["class"] = ["u-text--muted"]
+                    citation_p.string = element.get_text()
+                else:
+                    if len(citation_elements) == 2 and index == 0:
+                        citation_p["class"] = ["u-no-margin--bottom"]
+                    citation_p.append(element)
+                insert_after.insert_after(citation_p)
+                insert_after = citation_p
+
+        return soup
+    
+    def _replace_image_block(self, soup):
+        """
+        Given HTML soup, find image blocks wrapped with the ::: marker
+        and transform them into styled image container components.
+
+        Input:
+        <p>::: image-block</p>
+        <p><img src="..." alt="" width="800" height="450"/></p>
+        <p><em>Optional caption</em></p>
+        <p>:::</p>
+
+        Output:
+        <div class="p-image-container is-cover">
+            <img class="p-image-container__image" src="..." alt="" width="800">
+        </div>
+        <p class="u-text--muted">Optional caption</p>
+
+        The caption paragraph (the <em> tag) is optional.
+        """
+        for open_marker in soup.find_all("p"):
+            if not re.match(r"^:::\s*image-block", open_marker.get_text()):
+                continue
+
+            # Use get_text() check, same as other block parsers, to avoid
+            # missing matches when the <p> contains whitespace text nodes
+            close_marker = None
+            for sibling in open_marker.next_siblings:
+                print("sibling", sibling)
+                if (
+                    hasattr(sibling, "get_text")
+                    and sibling.name == "p"
+                    and sibling.get_text(strip=True) == ":::"
+                ):
+                    close_marker = sibling
+                    break
+            if not close_marker:
+                continue
+
+            # Collect tag siblings between the markers (skip NavigableStrings)
+            siblings = []
+            for sibling in open_marker.next_siblings:
+                if sibling is close_marker:
+                    break
+                if hasattr(sibling, "find"):
+                    siblings.append(sibling)
+
+            # Find the image and optional caption among the siblings
+            img = None
+            caption = None
+            for sibling in siblings:
+                if not img:
+                    found_img = sibling.find("img")
+                    if isinstance(found_img, Tag):
+                        img = found_img
+                if not caption:
+                    found_em = sibling.find("em")
+                    if isinstance(found_em, Tag):
+                        caption = found_em.get_text(strip=True)
+
+            if not img:
+                continue
+
+            # Build the image container
+            img["class"] = ["p-image-container__image"]
+            img.attrs.pop("height", None)
+            img.attrs.pop("role", None)
+            container = soup.new_tag("div")
+            container["class"] = ["p-image-container", "is-cover"]
+            container.append(img.extract())
+
+            # Replace open marker with the container, clean up remaining siblings
+            open_marker.replace_with(container)
+            for sibling in siblings:
+                sibling.decompose()
+            close_marker.decompose()
+
+            # Insert optional caption after the container
+            if caption:
+                caption_p = soup.new_tag("p")
+                caption_p["class"] = ["u-text--muted"]
+                caption_p.string = caption
+                container.insert_after(caption_p)
+
+        return soup
+
+    def _replace_highlights_block(self, soup):
+        """
+        Given HTML soup, find highlights blocks wrapped with the ::: marker
+        and transform them into styled highlight list components.
+
+        Input:
+        <p>::: highlights-block</p>
+        <ul>
+            <li>Highlight 1</li>
+            <li>Highlight 2</li>
+        </ul>
+        <p>:::</p>
+
+        Or with an optional title:
+        <p>::: highlights-block<br/><strong>My Title</strong></p>
+        ...
+
+        Output:
+        <p class="p-text--small-caps">My Title</p>  <!-- optional -->
+        <ul class="p-list--divided is-split">
+            <li class="p-list__item is-ticked">Highlight 1</li>
+            <li class="p-list__item is-ticked">Highlight 2</li>
+        </ul>
+
+        Note: the ul/li classes are applied here; _replace_lists will be
+        skipped for these elements since the classes are already present.
+        """
+        for open_marker in soup.find_all("p"):
+            if not re.match(r"^:::\s*highlights-block", open_marker.get_text()):
+                continue
+
+            # Extract optional title — may be in a <strong> tag after a <br>
+            strong = open_marker.find("strong")
+            title = strong.get_text(strip=True) if strong else ""
+
+            ul = open_marker.find_next_sibling("ul")
+            close_marker = open_marker.find_next_sibling("p", string=":::")
+
+            if not ul or not close_marker:
+                continue
+
+            # Apply classes to each <li>, unwrapping any inner <p> if present
+            for li in ul.find_all("li", recursive=False):
+                inner_p = li.find("p")
+                if inner_p:
+                    li.clear()
+                    li.string = inner_p.get_text()
+                li["class"] = ["p-list__item", "is-ticked"]
+
+            ul["class"] = ["p-list--divided", "is-split"]
+
+            # Insert optional title before the list
+            if title:
+                title_p = soup.new_tag("p")
+                title_p["class"] = ["p-text--small-caps"]
+                title_p.string = title
+                open_marker.replace_with(title_p)
+                title_p.insert_after(ul.extract())
+            else:
+                open_marker.replace_with(ul.extract())
+
+            close_marker.decompose()
 
         return soup
 

--- a/canonicalwebteam/discourse/parsers/base_parser.py
+++ b/canonicalwebteam/discourse/parsers/base_parser.py
@@ -3,7 +3,6 @@ import copy
 from functools import cached_property
 import os
 import re
-import flask
 from urllib.parse import urlparse, urlunparse
 from canonicalwebteam.discourse.exceptions import _capture_sentry_message
 
@@ -891,7 +890,10 @@ class BaseParser:
                 if "p-list__item" in li.get("class", []):
                     continue
                 checkbox = li.find(
-                    "span", class_=lambda c: c and "chcklst-box" in c and "checked" in c
+                    "span",
+                    class_=lambda c: c
+                    and "chcklst-box" in c
+                    and "checked" in c,
                 )
                 if checkbox:
                     checkbox.decompose()
@@ -926,8 +928,9 @@ class BaseParser:
           <table>
             <thead><tr><th>QUOTE BLOCK</th><th></th><th></th></tr></thead>
             <tbody>
-              <tr><td>QUOTE</td><td>NAME</td><td>POSITION AND COMPANY</td></tr>
-              <tr><td>"Quote text."</td><td>Author</td><td>Organisation</td></tr>
+              <tr><td>QUOTE</td><td>NAME</td><td>POSITION/COMPANY</td></tr>
+              <tr><td>"Quote text."</td><td>Author</td><td>Organization</td>
+              </tr>
             </tbody>
           </table>
         </div>
@@ -956,7 +959,7 @@ class BaseParser:
             if not cells:
                 continue
 
-            quote_text = cells[0].get_text(strip=True) if len(cells) > 0 else ""
+            quote_text = cells[0].get_text(strip=True)
             name = cells[1].get_text(strip=True) if len(cells) > 1 else ""
             position = cells[2].get_text(strip=True) if len(cells) > 2 else ""
 
@@ -1004,7 +1007,7 @@ class BaseParser:
                 insert_after = citation_p
 
         return soup
-    
+
     def _replace_image_block(self, soup):
         """
         Given HTML soup, find image block tables and transform them into
@@ -1015,8 +1018,8 @@ class BaseParser:
           <table>
             <thead><tr><th>IMAGE BLOCK</th><th></th></tr></thead>
             <tbody>
-              <tr><td>IMAGE CAPTION (OPTIONAL) ...</td><td>ASSET LINK ...</td></tr>
-              <tr><td>This is a caption</td><td><a href="https://...">https://...</a></td></tr>
+              <tr><td>IMAGE CAPTION (OPTIONAL)</td><td>ASSET LINK</td></tr>
+              <tr><td>This is a caption</td><td><a href="#">#</a></td></tr>
             </tbody>
           </table>
         </div>
@@ -1027,7 +1030,8 @@ class BaseParser:
         </div>
         <p class="u-text--muted">This is a caption</p>
 
-        The caption cell is optional. If no caption, u-sv3 is added to the container.
+        The caption cell is optional. If no caption, u-sv3 is added
+        to the container.
         """
         for md_table in soup.find_all("div", class_="md-table"):
             table = md_table.find("table")
@@ -1049,7 +1053,9 @@ class BaseParser:
             # The asset link cell may contain an <a> tag or plain text
             link_cell = cells[1]
             a_tag = link_cell.find("a")
-            img_src = a_tag["href"] if a_tag else link_cell.get_text(strip=True)
+            img_src = (
+                a_tag["href"] if a_tag else link_cell.get_text(strip=True)
+            )
 
             if not img_src:
                 continue
@@ -1075,6 +1081,15 @@ class BaseParser:
                 container["class"].append("u-sv3")
 
         return soup
+
+    def _get_md_table_marker(self, md_table: Tag):
+        """Return the marker text from the first <th> in an md-table, or ''."""
+
+        table = md_table.find("table")
+        if not table:
+            return ""
+        first_th = table.find("th")
+        return first_th.get_text(strip=True) if first_th else ""
 
     def _replace_highlights_block(self, soup):
         """
@@ -1114,8 +1129,7 @@ class BaseParser:
             table = md_table.find("table")
             if not table:
                 continue
-            first_th = table.find("th")
-            if not first_th or "HIGHLIGHTS BLOCK" not in first_th.get_text():
+            if "HIGHLIGHTS BLOCK" not in self._get_md_table_marker(md_table):
                 continue
 
             # The last tbody row holds the actual data
@@ -1130,14 +1144,14 @@ class BaseParser:
             items_cell = cells[1]
 
             # Extract highlight items — text nodes between :check_mark: images
-            items = []
-            for img in items_cell.find_all(
+            check_imgs = items_cell.find_all(
                 "img", title=lambda t: t and "check_mark" in t
-            ):
-                # Collect all text after this img up to the next img
+            )
+            items = []
+            for check_img in check_imgs:
                 text_parts = []
-                for sibling in img.next_siblings:
-                    if hasattr(sibling, "name") and sibling.name == "img":
+                for sibling in check_img.next_siblings:
+                    if getattr(sibling, "name", None) == "img":
                         break
                     if isinstance(sibling, NavigableString):
                         text_parts.append(str(sibling))
@@ -1190,16 +1204,15 @@ class BaseParser:
           <li class="p-list__item is-ticked">Second item</li>
         </ul>
         """
-        # Find all check_mark images, then group by their parent <p>
-        seen = set()
-        paragraphs = []
-        for img in soup.find_all("img", title=lambda t: t and "check_mark" in t):
-            p = img.find_parent("p")
-            if p and id(p) not in seen:
-                seen.add(id(p))
-                paragraphs.append(p)
+        # Convert each paragraph at most once.
+        paragraphs = {
+            img.find_parent("p")
+            for img in soup.find_all(
+                "img", title=lambda t: t and "check_mark" in t
+            )
+        }
 
-        for p in paragraphs:
+        for p in filter(None, paragraphs):
             check_marks = p.find_all(
                 "img", title=lambda t: t and "check_mark" in t
             )
@@ -1208,13 +1221,13 @@ class BaseParser:
             for img in check_marks:
                 text_parts = []
                 for sibling in img.next_siblings:
-                    if hasattr(sibling, "name"):
-                        if sibling.name == "br":
-                            break
-                        if sibling.name == "img" and sibling.get(
-                            "title", ""
-                        ) and "check_mark" in sibling.get("title", ""):
-                            break
+                    sibling_name = getattr(sibling, "name", None)
+                    if sibling_name == "br":
+                        break
+                    if sibling_name == "img" and "check_mark" in sibling.get(
+                        "title", ""
+                    ):
+                        break
                     if isinstance(sibling, NavigableString):
                         text_parts.append(str(sibling))
                 item_text = "".join(text_parts).strip()
@@ -1269,8 +1282,7 @@ class BaseParser:
             table = md_table.find("table")
             if not table:
                 continue
-            first_th = table.find("th")
-            if not first_th or "STANDARD TABLE" not in first_th.get_text():
+            if "STANDARD TABLE" not in self._get_md_table_marker(md_table):
                 continue
 
             rows = table.select("tbody tr")

--- a/canonicalwebteam/discourse/parsers/base_parser.py
+++ b/canonicalwebteam/discourse/parsers/base_parser.py
@@ -970,6 +970,8 @@ class BaseParser:
 
             # Replace the entire wrapper (open marker, blockquote, close
             # marker) with the new markup
+            if not citation_elements:
+                quote_p["class"].append("u-sv3")
             open_marker.replace_with(quote_p)
             blockquote.decompose()
             close_marker.decompose()
@@ -1075,6 +1077,9 @@ class BaseParser:
                 caption_p["class"] = ["u-text--muted"]
                 caption_p.string = caption
                 container.insert_after(caption_p)
+            else:
+                # If there's no caption add some spacing below
+                container["class"].append("u-sv3")
 
         return soup
 
@@ -1127,17 +1132,23 @@ class BaseParser:
                     li.string = inner_p.get_text()
                 li["class"] = ["p-list__item", "is-ticked"]
 
-            ul["class"] = ["p-list--divided", "is-split"]
+            ul["class"] = ["p-list--horizontal-section"]
 
-            # Insert optional title before the list
+            # Wrap the ul in a div container
+            wrapper = soup.new_tag("div")
+            wrapper["class"] = ["p-list--horizontal-section-wrapper"]
+            ul.replace_with(wrapper)
+            wrapper.append(ul)
+
+            # Insert optional title before the wrapper
             if title:
                 title_p = soup.new_tag("p")
                 title_p["class"] = ["p-text--small-caps"]
                 title_p.string = title
                 open_marker.replace_with(title_p)
-                title_p.insert_after(ul.extract())
+                title_p.insert_after(wrapper)
             else:
-                open_marker.replace_with(ul.extract())
+                open_marker.replace_with(wrapper)
 
             close_marker.decompose()
 

--- a/canonicalwebteam/discourse/parsers/base_parser.py
+++ b/canonicalwebteam/discourse/parsers/base_parser.py
@@ -549,6 +549,8 @@ class BaseParser:
         soup = self._replace_blockquotes_block(soup)
         soup = self._replace_highlights_block(soup)
         soup = self._replace_image_block(soup)
+        soup = self._replace_standard_table_block(soup)
+        soup = self._replace_checklist_paragraph(soup)
         soup = self._replace_image_src(soup)
         soup = self._replace_links(soup)
         soup = self._replace_polls(soup)
@@ -916,41 +918,48 @@ class BaseParser:
 
     def _replace_blockquotes_block(self, soup):
         """
-        Given HTML soup, find quote blocks wrapped with the ::: marker and
-        transform them into styled quote components.
+        Given HTML soup, find quote block tables and transform them into
+        styled quote components.
 
         Input:
-        <p>::: quote-block</p>
-        <blockquote>
-            <p>"Quote text."</p>
-            <p>— <strong>Author</strong>, <em>Organisation</em></p>
-        </blockquote>
-        <p>:::</p>
+        <div class="md-table">
+          <table>
+            <thead><tr><th>QUOTE BLOCK</th><th></th><th></th></tr></thead>
+            <tbody>
+              <tr><td>QUOTE</td><td>NAME</td><td>POSITION AND COMPANY</td></tr>
+              <tr><td>"Quote text."</td><td>Author</td><td>Organisation</td></tr>
+            </tbody>
+          </table>
+        </div>
 
         Output:
-        <p class="p-heading--2"><i>"Quote text."</i></p>
-        <strong>Author</strong>
-        <em>Organisation</em>
+        <p class="p-heading--4"><i>"Quote text."</i></p>
+        <p class="u-no-margin--bottom"><strong>Author</strong></p>
+        <p class="u-text--muted">Organisation</p>
 
-        The citation paragraph (second <p> inside the blockquote) is optional,
-        and may contain any combination of <strong> (name) and <em>
-        (organisation).
+        The name and position columns are optional. If neither is present,
+        the quote element gets the class 'u-sv3' for bottom spacing.
         """
-        for open_marker in soup.find_all("p", string="::: quote-block"):
-            blockquote = open_marker.find_next_sibling("blockquote")
-            close_marker = open_marker.find_next_sibling(
-                "p", string=":::"
-            )
-
-            if not blockquote or not close_marker:
+        for md_table in soup.find_all("div", class_="md-table"):
+            table = md_table.find("table")
+            if not table:
+                continue
+            first_th = table.find("th")
+            if not first_th or "QUOTE BLOCK" not in first_th.get_text():
                 continue
 
-            paragraphs = blockquote.find_all("p", recursive=False)
-            if not paragraphs:
+            # The last tbody row holds the actual data
+            rows = table.select("tbody tr")
+            if len(rows) < 2:
+                continue
+            cells = rows[-1].find_all("td")
+            if not cells:
                 continue
 
-            # First paragraph holds the quote text
-            quote_text = paragraphs[0].get_text(strip=True)
+            quote_text = cells[0].get_text(strip=True) if len(cells) > 0 else ""
+            name = cells[1].get_text(strip=True) if len(cells) > 1 else ""
+            position = cells[2].get_text(strip=True) if len(cells) > 2 else ""
+
             if not quote_text:
                 continue
 
@@ -961,25 +970,26 @@ class BaseParser:
             quote_i.string = quote_text
             quote_p.append(quote_i)
 
-            # Collect citation elements (<strong> and/or <em>) from the
-            # optional second paragraph, preserving document order
+            # Build citation elements from name and position columns
             citation_elements = []
-            if len(paragraphs) > 1:
-                for tag in paragraphs[1].find_all(["strong", "em"]):
-                    citation_elements.append(copy.copy(tag))
+            if name:
+                strong = soup.new_tag("strong")
+                strong.string = name
+                citation_elements.append(strong)
+            if position:
+                em = soup.new_tag("em")
+                em.string = position
+                citation_elements.append(em)
 
-            # Replace the entire wrapper (open marker, blockquote, close
-            # marker) with the new markup
             if not citation_elements:
                 quote_p["class"].append("u-sv3")
-            open_marker.replace_with(quote_p)
-            blockquote.decompose()
-            close_marker.decompose()
+
+            md_table.replace_with(quote_p)
 
             # Insert citation elements after the quote, preserving order.
             # <strong> is wrapped in a <p> (with u-no-margin--bottom when
-            # followed by a second element); <em> becomes a plain <p
-            # class="u-text--muted"> containing just the text.
+            # followed by a second element); <em> becomes a plain
+            # <p class="u-text--muted"> containing just the text.
             insert_after = quote_p
             for index, element in enumerate(citation_elements):
                 citation_p = soup.new_tag("p")
@@ -997,160 +1007,298 @@ class BaseParser:
     
     def _replace_image_block(self, soup):
         """
-        Given HTML soup, find image blocks wrapped with the ::: marker
-        and transform them into styled image container components.
+        Given HTML soup, find image block tables and transform them into
+        styled image container components.
 
         Input:
-        <p>::: image-block</p>
-        <p><img src="..." alt="" width="800" height="450"/></p>
-        <p><em>Optional caption</em></p>
-        <p>:::</p>
+        <div class="md-table">
+          <table>
+            <thead><tr><th>IMAGE BLOCK</th><th></th></tr></thead>
+            <tbody>
+              <tr><td>IMAGE CAPTION (OPTIONAL) ...</td><td>ASSET LINK ...</td></tr>
+              <tr><td>This is a caption</td><td><a href="https://...">https://...</a></td></tr>
+            </tbody>
+          </table>
+        </div>
 
         Output:
         <div class="p-image-container is-cover">
-            <img class="p-image-container__image" src="..." alt="" width="800">
+            <img class="p-image-container__image" src="https://..." alt="">
         </div>
-        <p class="u-text--muted">Optional caption</p>
+        <p class="u-text--muted">This is a caption</p>
 
-        The caption paragraph (the <em> tag) is optional.
+        The caption cell is optional. If no caption, u-sv3 is added to the container.
         """
-        for open_marker in soup.find_all("p"):
-            if not re.match(r"^:::\s*image-block", open_marker.get_text()):
+        for md_table in soup.find_all("div", class_="md-table"):
+            table = md_table.find("table")
+            if not table:
+                continue
+            first_th = table.find("th")
+            if not first_th or "IMAGE BLOCK" not in first_th.get_text():
                 continue
 
-            # Use get_text() check, same as other block parsers, to avoid
-            # missing matches when the <p> contains whitespace text nodes
-            close_marker = None
-            for sibling in open_marker.next_siblings:
-                print("sibling", sibling)
-                if (
-                    hasattr(sibling, "get_text")
-                    and sibling.name == "p"
-                    and sibling.get_text(strip=True) == ":::"
-                ):
-                    close_marker = sibling
-                    break
-            if not close_marker:
+            # The last tbody row holds the actual data
+            rows = table.select("tbody tr")
+            if len(rows) < 2:
+                continue
+            cells = rows[-1].find_all("td")
+            if len(cells) < 2:
                 continue
 
-            # Collect tag siblings between the markers (skip NavigableStrings)
-            siblings = []
-            for sibling in open_marker.next_siblings:
-                if sibling is close_marker:
-                    break
-                if hasattr(sibling, "find"):
-                    siblings.append(sibling)
+            caption = cells[0].get_text(strip=True)
+            # The asset link cell may contain an <a> tag or plain text
+            link_cell = cells[1]
+            a_tag = link_cell.find("a")
+            img_src = a_tag["href"] if a_tag else link_cell.get_text(strip=True)
 
-            # Find the image and optional caption among the siblings
-            img = None
-            caption = None
-            for sibling in siblings:
-                if not img:
-                    found_img = sibling.find("img")
-                    if isinstance(found_img, Tag):
-                        img = found_img
-                if not caption:
-                    found_em = sibling.find("em")
-                    if isinstance(found_em, Tag):
-                        caption = found_em.get_text(strip=True)
-
-            if not img:
+            if not img_src:
                 continue
 
             # Build the image container
+            img = soup.new_tag("img")
+            img["src"] = img_src
+            img["alt"] = ""
             img["class"] = ["p-image-container__image"]
-            img.attrs.pop("height", None)
-            img.attrs.pop("role", None)
+
             container = soup.new_tag("div")
             container["class"] = ["p-image-container", "is-cover"]
-            container.append(img.extract())
+            container.append(img)
 
-            # Replace open marker with the container, clean up remaining siblings
-            open_marker.replace_with(container)
-            for sibling in siblings:
-                sibling.decompose()
-            close_marker.decompose()
+            md_table.replace_with(container)
 
-            # Insert optional caption after the container
             if caption:
                 caption_p = soup.new_tag("p")
                 caption_p["class"] = ["u-text--muted"]
                 caption_p.string = caption
                 container.insert_after(caption_p)
             else:
-                # If there's no caption add some spacing below
                 container["class"].append("u-sv3")
 
         return soup
 
     def _replace_highlights_block(self, soup):
         """
-        Given HTML soup, find highlights blocks wrapped with the ::: marker
-        and transform them into styled highlight list components.
+        Given HTML soup, find highlights block tables and transform them into
+        styled highlight list components.
 
         Input:
-        <p>::: highlights-block</p>
-        <ul>
-            <li>Highlight 1</li>
-            <li>Highlight 2</li>
-        </ul>
-        <p>:::</p>
-
-        Or with an optional title:
-        <p>::: highlights-block<br/><strong>My Title</strong></p>
-        ...
+        <div class="md-table">
+          <table>
+            <thead><tr><th>HIGHLIGHTS BLOCK</th><th></th></tr></thead>
+            <tbody>
+              <tr><td>TITLE</td><td>ITEMS</td></tr>
+              <tr>
+                <td>Add title here</td>
+                <td>
+                  <img title=":check_mark:"/>Highlight 1
+                  <img title=":check_mark:"/>Highlight 2
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
 
         Output:
-        <p class="p-text--small-caps">My Title</p>  <!-- optional -->
-        <ul class="p-list--divided is-split">
+        <p class="p-text--small-caps">Add title here</p>  <!-- optional -->
+        <div class="p-list--horizontal-section-wrapper">
+          <ul class="p-list--horizontal-section">
             <li class="p-list__item is-ticked">Highlight 1</li>
             <li class="p-list__item is-ticked">Highlight 2</li>
-        </ul>
+          </ul>
+        </div>
 
-        Note: the ul/li classes are applied here; _replace_lists will be
-        skipped for these elements since the classes are already present.
+        Items are split by :check_mark: emoji images in the ITEMS cell.
+        The title is optional — if the title cell is empty no title is emitted.
         """
-        for open_marker in soup.find_all("p"):
-            if not re.match(r"^:::\s*highlights-block", open_marker.get_text()):
+        for md_table in soup.find_all("div", class_="md-table"):
+            table = md_table.find("table")
+            if not table:
+                continue
+            first_th = table.find("th")
+            if not first_th or "HIGHLIGHTS BLOCK" not in first_th.get_text():
                 continue
 
-            # Extract optional title — may be in a <strong> tag after a <br>
-            strong = open_marker.find("strong")
-            title = strong.get_text(strip=True) if strong else ""
-
-            ul = open_marker.find_next_sibling("ul")
-            close_marker = open_marker.find_next_sibling("p", string=":::")
-
-            if not ul or not close_marker:
+            # The last tbody row holds the actual data
+            rows = table.select("tbody tr")
+            if len(rows) < 2:
+                continue
+            cells = rows[-1].find_all("td")
+            if len(cells) < 2:
                 continue
 
-            # Apply classes to each <li>, unwrapping any inner <p> if present
-            for li in ul.find_all("li", recursive=False):
-                inner_p = li.find("p")
-                if inner_p:
-                    li.clear()
-                    li.string = inner_p.get_text()
-                li["class"] = ["p-list__item", "is-ticked"]
+            title = cells[0].get_text(strip=True)
+            items_cell = cells[1]
 
+            # Extract highlight items — text nodes between :check_mark: images
+            items = []
+            for img in items_cell.find_all(
+                "img", title=lambda t: t and "check_mark" in t
+            ):
+                # Collect all text after this img up to the next img
+                text_parts = []
+                for sibling in img.next_siblings:
+                    if hasattr(sibling, "name") and sibling.name == "img":
+                        break
+                    if isinstance(sibling, NavigableString):
+                        text_parts.append(str(sibling))
+                item_text = "".join(text_parts).strip()
+                if item_text:
+                    items.append(item_text)
+
+            if not items:
+                continue
+
+            # Build the list
+            ul = soup.new_tag("ul")
             ul["class"] = ["p-list--horizontal-section"]
+            for item in items:
+                li = soup.new_tag("li")
+                li["class"] = ["p-list__item", "is-ticked"]
+                li.string = item
+                ul.append(li)
 
-            # Wrap the ul in a div container
             wrapper = soup.new_tag("div")
             wrapper["class"] = ["p-list--horizontal-section-wrapper"]
-            ul.replace_with(wrapper)
             wrapper.append(ul)
 
-            # Insert optional title before the wrapper
             if title:
                 title_p = soup.new_tag("p")
                 title_p["class"] = ["p-text--small-caps"]
                 title_p.string = title
-                open_marker.replace_with(title_p)
+                md_table.replace_with(title_p)
                 title_p.insert_after(wrapper)
             else:
-                open_marker.replace_with(wrapper)
+                md_table.replace_with(wrapper)
 
-            close_marker.decompose()
+        return soup
+
+    def _replace_checklist_paragraph(self, soup):
+        """
+        Given HTML soup, find <p> elements that use check_mark emoji images as
+        bullet points (separated by <br/> tags or consecutive images) and
+        replace them with a styled <ul> list.
+
+        Input:
+        <p>
+          <img title=":check_mark:" .../>First item<br/>
+          <img title=":check_mark:" .../>Second item
+        </p>
+
+        Output:
+        <ul class="p-list--divided">
+          <li class="p-list__item is-ticked">First item</li>
+          <li class="p-list__item is-ticked">Second item</li>
+        </ul>
+        """
+        # Find all check_mark images, then group by their parent <p>
+        seen = set()
+        paragraphs = []
+        for img in soup.find_all("img", title=lambda t: t and "check_mark" in t):
+            p = img.find_parent("p")
+            if p and id(p) not in seen:
+                seen.add(id(p))
+                paragraphs.append(p)
+
+        for p in paragraphs:
+            check_marks = p.find_all(
+                "img", title=lambda t: t and "check_mark" in t
+            )
+
+            items = []
+            for img in check_marks:
+                text_parts = []
+                for sibling in img.next_siblings:
+                    if hasattr(sibling, "name"):
+                        if sibling.name == "br":
+                            break
+                        if sibling.name == "img" and sibling.get(
+                            "title", ""
+                        ) and "check_mark" in sibling.get("title", ""):
+                            break
+                    if isinstance(sibling, NavigableString):
+                        text_parts.append(str(sibling))
+                item_text = "".join(text_parts).strip()
+                if item_text:
+                    items.append(item_text)
+
+            if not items:
+                continue
+
+            ul = soup.new_tag("ul")
+            ul["class"] = ["p-list--divided"]
+            for item in items:
+                li = soup.new_tag("li")
+                li["class"] = ["p-list__item", "is-ticked"]
+                li.string = item
+                ul.append(li)
+
+            p.replace_with(ul)
+
+        return soup
+
+    def _replace_standard_table_block(self, soup):
+        """
+        Given HTML soup, find standard table blocks and transform them into
+        plain HTML tables, removing the md-table wrapper and the marker header
+        row, and promoting the first data row into a proper <thead>.
+
+        Input:
+        <div class="md-table">
+          <table>
+            <thead><tr><th>STANDARD TABLE</th><th></th>...</tr></thead>
+            <tbody>
+              <tr><td>Header 1</td><td>Header 2</td>...</tr>
+              <tr><td>Row 1</td><td>Row 1</td>...</tr>
+              ...
+            </tbody>
+          </table>
+        </div>
+
+        Output:
+        <table>
+          <thead>
+            <tr><th>Header 1</th><th>Header 2</th>...</tr>
+          </thead>
+          <tbody>
+            <tr><td>Row 1</td><td>Row 1</td>...</tr>
+            ...
+          </tbody>
+        </table>
+        """
+        for md_table in soup.find_all("div", class_="md-table"):
+            table = md_table.find("table")
+            if not table:
+                continue
+            first_th = table.find("th")
+            if not first_th or "STANDARD TABLE" not in first_th.get_text():
+                continue
+
+            rows = table.select("tbody tr")
+            if not rows:
+                continue
+
+            # First tbody row becomes the new <thead>
+            header_row = rows[0]
+            new_thead = soup.new_tag("thead")
+            new_tr = soup.new_tag("tr")
+            for td in header_row.find_all("td"):
+                th = soup.new_tag("th")
+                th.string = td.get_text(strip=True)
+                if td.get("style"):
+                    th["style"] = td["style"]
+                new_tr.append(th)
+            new_thead.append(new_tr)
+
+            # Remaining rows stay in <tbody>
+            new_tbody = soup.new_tag("tbody")
+            for row in rows[1:]:
+                new_tbody.append(row.extract())
+
+            new_table = soup.new_tag("table")
+            new_table.append(new_thead)
+            new_table.append(new_tbody)
+
+            md_table.replace_with(new_table)
 
         return soup
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -12,7 +12,6 @@ import requests
 from canonicalwebteam.discourse import DiscourseAPI, Tutorials, TutorialParser
 from tests.fixtures.forum_mock import register_uris
 
-
 this_dir = os.path.dirname(os.path.realpath(__file__))
 template_folder = f"{this_dir}/fixtures/templates"
 

--- a/tests/test_engage_pages.py
+++ b/tests/test_engage_pages.py
@@ -6,7 +6,6 @@ from vcr_unittest import VCRTestCase
 
 from canonicalwebteam.discourse import DiscourseAPI, EngagePages
 
-
 this_dir = os.path.dirname(os.path.realpath(__file__))
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -248,7 +248,9 @@ class TestReplaceBlockquotesBlock(unittest.TestCase):
 
     def test_quote_with_author_and_organisation(self):
         soup = self._parse(
-            self._make_table('"Another quote."', name="John Smith", position="Canonical")
+            self._make_table(
+                '"Another quote."', name="John Smith", position="Canonical"
+            )
         )
         quote_p = soup.find("p", class_="p-heading--4")
         self.assertIsNotNone(quote_p)
@@ -316,7 +318,9 @@ class TestReplaceImageBlock(unittest.TestCase):
         """
 
     def test_basic_image_no_caption(self):
-        soup = self._parse(self._make_table("https://assets.ubuntu.com/img/photo.jpg"))
+        soup = self._parse(
+            self._make_table("https://assets.ubuntu.com/img/photo.jpg")
+        )
         container = soup.find("div", class_="p-image-container")
         self.assertIsNotNone(container)
         self.assertIn("is-cover", container.get("class", []))
@@ -330,7 +334,10 @@ class TestReplaceImageBlock(unittest.TestCase):
 
     def test_image_with_caption(self):
         soup = self._parse(
-            self._make_table("https://assets.ubuntu.com/img/photo.jpg", caption="This is a caption")
+            self._make_table(
+                "https://assets.ubuntu.com/img/photo.jpg",
+                caption="This is a caption",
+            )
         )
         container = soup.find("div", class_="p-image-container")
         self.assertIsNotNone(container)
@@ -341,7 +348,9 @@ class TestReplaceImageBlock(unittest.TestCase):
         self.assertNotIn("u-sv3", container.get("class", []))
 
     def test_table_removed_after_transform(self):
-        soup = self._parse(self._make_table("https://assets.ubuntu.com/img/photo.jpg"))
+        soup = self._parse(
+            self._make_table("https://assets.ubuntu.com/img/photo.jpg")
+        )
         self.assertIsNone(soup.find("div", class_="md-table"))
         self.assertIsNone(soup.find("table"))
 
@@ -422,7 +431,9 @@ class TestReplaceHighlightsBlock(unittest.TestCase):
         self.assertIsNone(soup.find("p", class_="p-text--small-caps"))
 
     def test_highlights_with_title(self):
-        soup = self._parse(self._make_table(["Feature A"], title="Key features"))
+        soup = self._parse(
+            self._make_table(["Feature A"], title="Key features")
+        )
         title_p = soup.find("p", class_="p-text--small-caps")
         self.assertIsNotNone(title_p)
         self.assertEqual(title_p.string, "Key features")
@@ -456,7 +467,9 @@ class TestReplaceHighlightsBlock(unittest.TestCase):
         </div>
         """
         soup = self._parse(html)
-        self.assertIsNone(soup.find("div", class_="p-list--horizontal-section-wrapper"))
+        self.assertIsNone(
+            soup.find("div", class_="p-list--horizontal-section-wrapper")
+        )
 
     def test_non_highlights_table_is_ignored(self):
         html = """
@@ -468,7 +481,9 @@ class TestReplaceHighlightsBlock(unittest.TestCase):
         </div>
         """
         soup = self._parse(html)
-        self.assertIsNone(soup.find("div", class_="p-list--horizontal-section-wrapper"))
+        self.assertIsNone(
+            soup.find("div", class_="p-list--horizontal-section-wrapper")
+        )
         self.assertIsNotNone(soup.find("table"))
 
 
@@ -510,7 +525,9 @@ class TestReplaceStandardTableBlock(unittest.TestCase):
         self.assertIsNone(soup.find("div", class_="md-table"))
 
     def test_first_row_becomes_thead(self):
-        soup = self._parse(self._make_table(["Col A", "Col B"], [["v1", "v2"]]))
+        soup = self._parse(
+            self._make_table(["Col A", "Col B"], [["v1", "v2"]])
+        )
         table = soup.find("table")
         self.assertIsNotNone(table)
         thead = table.find("thead")
@@ -575,7 +592,10 @@ class TestReplaceChecklistParagraph(unittest.TestCase):
             BeautifulSoup(html, features="lxml")
         )
 
-    CHECK = '<img title=":check_mark:" class="emoji" alt=":check_mark:" src="/images/emoji/twitter/check_mark.png"/>'
+    CHECK = (
+        '<img title=":check_mark:" class="emoji" alt=":check_mark:"'
+        'src="/images/emoji/twitter/check_mark.png"/>'
+    )
 
     def test_basic_checklist_becomes_ul(self):
         html = f"<p>{self.CHECK}First item<br/>{self.CHECK}Second item</p>"
@@ -606,8 +626,7 @@ class TestReplaceChecklistParagraph(unittest.TestCase):
 
     def test_multiple_paragraphs_only_checklist_converted(self):
         html = (
-            "<p>Normal</p>"
-            f"<p>{self.CHECK}Item A<br/>{self.CHECK}Item B</p>"
+            "<p>Normal</p>" f"<p>{self.CHECK}Item A<br/>{self.CHECK}Item B</p>"
         )
         soup = self._parse(html)
         # Normal paragraph unchanged
@@ -618,7 +637,10 @@ class TestReplaceChecklistParagraph(unittest.TestCase):
         self.assertEqual(len(ul.find_all("li")), 2)
 
     def test_item_text_is_stripped(self):
-        html = f"<p>{self.CHECK}  Trimmed item  <br/>{self.CHECK}  Also trimmed  </p>"
+        html = (
+            f"<p>{self.CHECK}  Trimmed item  <br/>{self.CHECK}"
+            " Also trimmed  </p>"
+        )
         soup = self._parse(html)
         lis = soup.find_all("li")
         self.assertEqual(lis[0].get_text(), "Trimmed item")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -218,6 +218,8 @@ class TestReplaceBlockquotesBlock(unittest.TestCase):
         # No citation paragraphs
         self.assertIsNone(soup.find("p", class_="u-text--muted"))
         self.assertIsNone(soup.find("p", class_="u-no-margin--bottom"))
+        # Without citations the quote element gets u-sv3 for spacing
+        self.assertIn("u-sv3", quote_p.get("class", []))
 
     def test_quote_with_author_only(self):
         html = """
@@ -238,6 +240,8 @@ class TestReplaceBlockquotesBlock(unittest.TestCase):
         strong = soup.find("strong")
         self.assertIsNotNone(strong)
         self.assertEqual(strong.string, "Jane Doe")
+        # Has citations, so u-sv3 should not be added
+        self.assertNotIn("u-sv3", quote_p.get("class", []))
 
     def test_quote_with_author_and_organisation(self):
         html = """
@@ -401,10 +405,13 @@ class TestReplaceHighlightsBlock(unittest.TestCase):
         <p>:::</p>
         """
         soup = self._parse(html)
-        ul = soup.find("ul")
+        wrapper = soup.find("div", class_="p-list--horizontal-section-wrapper")
+        self.assertIsNotNone(wrapper)
+        ul = wrapper.find("ul")
         self.assertIsNotNone(ul)
-        self.assertIn("p-list--divided", ul.get("class", []))
-        self.assertIn("is-split", ul.get("class", []))
+        self.assertIn("p-list--horizontal-section", ul.get("class", []))
+        self.assertNotIn("p-list--divided", ul.get("class", []))
+        self.assertNotIn("is-split", ul.get("class", []))
         lis = ul.find_all("li")
         self.assertEqual(len(lis), 2)
         for li in lis:
@@ -425,9 +432,11 @@ class TestReplaceHighlightsBlock(unittest.TestCase):
         title_p = soup.find("p", class_="p-text--small-caps")
         self.assertIsNotNone(title_p)
         self.assertEqual(title_p.string, "Key features")
-        ul = soup.find("ul")
+        wrapper = soup.find("div", class_="p-list--horizontal-section-wrapper")
+        self.assertIsNotNone(wrapper)
+        ul = wrapper.find("ul")
         self.assertIsNotNone(ul)
-        self.assertIn("p-list--divided", ul.get("class", []))
+        self.assertIn("p-list--horizontal-section", ul.get("class", []))
 
     def test_inner_p_unwrapped(self):
         html = """
@@ -470,7 +479,7 @@ class TestReplaceHighlightsBlock(unittest.TestCase):
         soup = self._parse(html)
         ul = soup.find("ul")
         # ul should be unchanged — no classes applied
-        self.assertNotIn("p-list--divided", ul.get("class", []))
+        self.assertNotIn("p-list--horizontal-section", ul.get("class", []))
 
 
 class TestDocParser(unittest.TestCase):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -191,6 +191,288 @@ class TestBaseParser(unittest.TestCase):
         self.assertEqual("/t/sample--text/1", parsed_topic["topic_path"])
 
 
+class TestReplaceBlockquotesBlock(unittest.TestCase):
+    def setUp(self):
+        discourse_api = DiscourseAPI("https://base.url", session=MagicMock())
+        self.parser = BaseParser(
+            api=discourse_api,
+            index_topic_id=1,
+            url_prefix="/",
+        )
+
+    def _parse(self, html):
+        return self.parser._replace_blockquotes_block(
+            BeautifulSoup(html, features="lxml")
+        )
+
+    def test_basic_quote_no_citation(self):
+        html = """
+        <p>::: quote-block</p>
+        <blockquote><p>"Only the quote."</p></blockquote>
+        <p>:::</p>
+        """
+        soup = self._parse(html)
+        quote_p = soup.find("p", class_="p-heading--4")
+        self.assertIsNotNone(quote_p)
+        self.assertEqual(quote_p.find("i").string, '"Only the quote."')
+        # No citation paragraphs
+        self.assertIsNone(soup.find("p", class_="u-text--muted"))
+        self.assertIsNone(soup.find("p", class_="u-no-margin--bottom"))
+
+    def test_quote_with_author_only(self):
+        html = """
+        <p>::: quote-block</p>
+        <blockquote>
+            <p>"Quote text."</p>
+            <p>— <strong>Jane Doe</strong></p>
+        </blockquote>
+        <p>:::</p>
+        """
+        soup = self._parse(html)
+        quote_p = soup.find("p", class_="p-heading--4")
+        self.assertIsNotNone(quote_p)
+        self.assertEqual(quote_p.find("i").string, '"Quote text."')
+        # One citation element — no u-no-margin--bottom because len == 1
+        author_p = soup.find("p", class_="u-no-margin--bottom")
+        self.assertIsNone(author_p)
+        strong = soup.find("strong")
+        self.assertIsNotNone(strong)
+        self.assertEqual(strong.string, "Jane Doe")
+
+    def test_quote_with_author_and_organisation(self):
+        html = """
+        <p>::: quote-block</p>
+        <blockquote>
+            <p>"Another quote."</p>
+            <p>— <strong>John Smith</strong>, <em>Canonical</em></p>
+        </blockquote>
+        <p>:::</p>
+        """
+        soup = self._parse(html)
+        quote_p = soup.find("p", class_="p-heading--4")
+        self.assertIsNotNone(quote_p)
+        # Author paragraph gets u-no-margin--bottom when there are 2 citations
+        author_p = soup.find("p", class_="u-no-margin--bottom")
+        self.assertIsNotNone(author_p)
+        self.assertIsNotNone(author_p.find("strong"))
+        # Organisation paragraph gets u-text--muted
+        org_p = soup.find("p", class_="u-text--muted")
+        self.assertIsNotNone(org_p)
+        self.assertEqual(org_p.string, "Canonical")
+
+    def test_markers_and_blockquote_removed(self):
+        html = """
+        <p>::: quote-block</p>
+        <blockquote><p>"Text."</p></blockquote>
+        <p>:::</p>
+        """
+        soup = self._parse(html)
+        self.assertIsNone(soup.find("blockquote"))
+        # Neither open nor close marker should remain
+        for p in soup.find_all("p"):
+            self.assertNotIn(":::", p.get_text())
+
+    def test_missing_close_marker_is_skipped(self):
+        html = """
+        <p>::: quote-block</p>
+        <blockquote><p>"Text."</p></blockquote>
+        """
+        soup = self._parse(html)
+        # No transformation should have happened
+        self.assertIsNone(soup.find("p", class_="p-heading--4"))
+        self.assertIsNotNone(soup.find("blockquote"))
+
+    def test_missing_blockquote_is_skipped(self):
+        html = """
+        <p>::: quote-block</p>
+        <p>:::</p>
+        """
+        soup = self._parse(html)
+        self.assertIsNone(soup.find("p", class_="p-heading--4"))
+
+
+class TestReplaceImageBlock(unittest.TestCase):
+    def setUp(self):
+        discourse_api = DiscourseAPI("https://base.url", session=MagicMock())
+        self.parser = BaseParser(
+            api=discourse_api,
+            index_topic_id=1,
+            url_prefix="/",
+        )
+
+    def _parse(self, html):
+        return self.parser._replace_image_block(
+            BeautifulSoup(html, features="lxml")
+        )
+
+    def test_basic_image_no_caption(self):
+        html = """
+        <p>::: image-block</p>
+        <p><img src="/img/photo.jpg" alt="photo" width="800" height="450"/></p>
+        <p>:::</p>
+        """
+        soup = self._parse(html)
+        container = soup.find("div", class_="p-image-container")
+        self.assertIsNotNone(container)
+        self.assertIn("is-cover", container.get("class", []))
+        img = container.find("img")
+        self.assertIsNotNone(img)
+        self.assertIn("p-image-container__image", img.get("class", []))
+        self.assertEqual(img["src"], "/img/photo.jpg")
+        # height attribute should be stripped
+        self.assertNotIn("height", img.attrs)
+        # No caption
+        self.assertIsNone(soup.find("p", class_="u-text--muted"))
+
+    def test_image_with_caption(self):
+        html = """
+        <p>::: image-block</p>
+        <p><img src="/img/photo.jpg" alt="" width="800" height="450"/></p>
+        <p><em>This is a caption</em></p>
+        <p>:::</p>
+        """
+        soup = self._parse(html)
+        container = soup.find("div", class_="p-image-container")
+        self.assertIsNotNone(container)
+        caption_p = soup.find("p", class_="u-text--muted")
+        self.assertIsNotNone(caption_p)
+        self.assertEqual(caption_p.string, "This is a caption")
+
+    def test_role_attribute_removed(self):
+        html = """
+        <p>::: image-block</p>
+        <p><img src="/img/photo.jpg" role="presentation" width="100"/></p>
+        <p>:::</p>
+        """
+        soup = self._parse(html)
+        img = soup.find("img")
+        self.assertIsNotNone(img)
+        self.assertNotIn("role", img.attrs)
+
+    def test_markers_removed(self):
+        html = """
+        <p>::: image-block</p>
+        <p><img src="/img/photo.jpg" width="100"/></p>
+        <p>:::</p>
+        """
+        soup = self._parse(html)
+        for p in soup.find_all("p"):
+            self.assertNotIn(":::", p.get_text())
+
+    def test_missing_image_is_skipped(self):
+        html = """
+        <p>::: image-block</p>
+        <p>No image here.</p>
+        <p>:::</p>
+        """
+        soup = self._parse(html)
+        self.assertIsNone(soup.find("div", class_="p-image-container"))
+
+    def test_missing_close_marker_is_skipped(self):
+        html = """
+        <p>::: image-block</p>
+        <p><img src="/img/photo.jpg" width="100"/></p>
+        """
+        soup = self._parse(html)
+        self.assertIsNone(soup.find("div", class_="p-image-container"))
+
+
+class TestReplaceHighlightsBlock(unittest.TestCase):
+    def setUp(self):
+        discourse_api = DiscourseAPI("https://base.url", session=MagicMock())
+        self.parser = BaseParser(
+            api=discourse_api,
+            index_topic_id=1,
+            url_prefix="/",
+        )
+
+    def _parse(self, html):
+        return self.parser._replace_highlights_block(
+            BeautifulSoup(html, features="lxml")
+        )
+
+    def test_basic_highlights_no_title(self):
+        html = """
+        <p>::: highlights-block</p>
+        <ul>
+            <li>Highlight 1</li>
+            <li>Highlight 2</li>
+        </ul>
+        <p>:::</p>
+        """
+        soup = self._parse(html)
+        ul = soup.find("ul")
+        self.assertIsNotNone(ul)
+        self.assertIn("p-list--divided", ul.get("class", []))
+        self.assertIn("is-split", ul.get("class", []))
+        lis = ul.find_all("li")
+        self.assertEqual(len(lis), 2)
+        for li in lis:
+            self.assertIn("p-list__item", li.get("class", []))
+            self.assertIn("is-ticked", li.get("class", []))
+        # No title paragraph
+        self.assertIsNone(soup.find("p", class_="p-text--small-caps"))
+
+    def test_highlights_with_title(self):
+        html = """
+        <p>::: highlights-block<br/><strong>Key features</strong></p>
+        <ul>
+            <li>Feature A</li>
+        </ul>
+        <p>:::</p>
+        """
+        soup = self._parse(html)
+        title_p = soup.find("p", class_="p-text--small-caps")
+        self.assertIsNotNone(title_p)
+        self.assertEqual(title_p.string, "Key features")
+        ul = soup.find("ul")
+        self.assertIsNotNone(ul)
+        self.assertIn("p-list--divided", ul.get("class", []))
+
+    def test_inner_p_unwrapped(self):
+        html = """
+        <p>::: highlights-block</p>
+        <ul>
+            <li><p>Wrapped item</p></li>
+        </ul>
+        <p>:::</p>
+        """
+        soup = self._parse(html)
+        li = soup.find("li")
+        self.assertIsNotNone(li)
+        # Inner <p> should have been unwrapped
+        self.assertIsNone(li.find("p"))
+        self.assertEqual(li.get_text(strip=True), "Wrapped item")
+
+    def test_markers_removed(self):
+        html = """
+        <p>::: highlights-block</p>
+        <ul><li>Item</li></ul>
+        <p>:::</p>
+        """
+        soup = self._parse(html)
+        for p in soup.find_all("p"):
+            self.assertNotIn(":::", p.get_text())
+
+    def test_missing_ul_is_skipped(self):
+        html = """
+        <p>::: highlights-block</p>
+        <p>:::</p>
+        """
+        soup = self._parse(html)
+        self.assertIsNone(soup.find("ul"))
+
+    def test_missing_close_marker_is_skipped(self):
+        html = """
+        <p>::: highlights-block</p>
+        <ul><li>Item</li></ul>
+        """
+        soup = self._parse(html)
+        ul = soup.find("ul")
+        # ul should be unchanged — no classes applied
+        self.assertNotIn("p-list--divided", ul.get("class", []))
+
+
 class TestDocParser(unittest.TestCase):
     def setUp(self):
         # Suppress annoying warnings from HTTPretty

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -205,13 +205,25 @@ class TestReplaceBlockquotesBlock(unittest.TestCase):
             BeautifulSoup(html, features="lxml")
         )
 
-    def test_basic_quote_no_citation(self):
-        html = """
-        <p>::: quote-block</p>
-        <blockquote><p>"Only the quote."</p></blockquote>
-        <p>:::</p>
+    def _make_table(self, quote, name="", position=""):
+        return f"""
+        <div class="md-table">
+          <table>
+            <thead><tr><th>QUOTE BLOCK</th><th></th><th></th></tr></thead>
+            <tbody>
+              <tr><td>QUOTE</td><td>NAME</td><td>POSITION AND COMPANY</td></tr>
+              <tr>
+                <td>{quote}</td>
+                <td>{name}</td>
+                <td>{position}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
         """
-        soup = self._parse(html)
+
+    def test_basic_quote_no_citation(self):
+        soup = self._parse(self._make_table('"Only the quote."'))
         quote_p = soup.find("p", class_="p-heading--4")
         self.assertIsNotNone(quote_p)
         self.assertEqual(quote_p.find("i").string, '"Only the quote."')
@@ -222,21 +234,12 @@ class TestReplaceBlockquotesBlock(unittest.TestCase):
         self.assertIn("u-sv3", quote_p.get("class", []))
 
     def test_quote_with_author_only(self):
-        html = """
-        <p>::: quote-block</p>
-        <blockquote>
-            <p>"Quote text."</p>
-            <p>— <strong>Jane Doe</strong></p>
-        </blockquote>
-        <p>:::</p>
-        """
-        soup = self._parse(html)
+        soup = self._parse(self._make_table('"Quote text."', name="Jane Doe"))
         quote_p = soup.find("p", class_="p-heading--4")
         self.assertIsNotNone(quote_p)
         self.assertEqual(quote_p.find("i").string, '"Quote text."')
         # One citation element — no u-no-margin--bottom because len == 1
-        author_p = soup.find("p", class_="u-no-margin--bottom")
-        self.assertIsNone(author_p)
+        self.assertIsNone(soup.find("p", class_="u-no-margin--bottom"))
         strong = soup.find("strong")
         self.assertIsNotNone(strong)
         self.assertEqual(strong.string, "Jane Doe")
@@ -244,15 +247,9 @@ class TestReplaceBlockquotesBlock(unittest.TestCase):
         self.assertNotIn("u-sv3", quote_p.get("class", []))
 
     def test_quote_with_author_and_organisation(self):
-        html = """
-        <p>::: quote-block</p>
-        <blockquote>
-            <p>"Another quote."</p>
-            <p>— <strong>John Smith</strong>, <em>Canonical</em></p>
-        </blockquote>
-        <p>:::</p>
-        """
-        soup = self._parse(html)
+        soup = self._parse(
+            self._make_table('"Another quote."', name="John Smith", position="Canonical")
+        )
         quote_p = soup.find("p", class_="p-heading--4")
         self.assertIsNotNone(quote_p)
         # Author paragraph gets u-no-margin--bottom when there are 2 citations
@@ -264,35 +261,28 @@ class TestReplaceBlockquotesBlock(unittest.TestCase):
         self.assertIsNotNone(org_p)
         self.assertEqual(org_p.string, "Canonical")
 
-    def test_markers_and_blockquote_removed(self):
-        html = """
-        <p>::: quote-block</p>
-        <blockquote><p>"Text."</p></blockquote>
-        <p>:::</p>
-        """
-        soup = self._parse(html)
-        self.assertIsNone(soup.find("blockquote"))
-        # Neither open nor close marker should remain
-        for p in soup.find_all("p"):
-            self.assertNotIn(":::", p.get_text())
+    def test_table_removed_after_transform(self):
+        soup = self._parse(self._make_table('"Text."'))
+        self.assertIsNone(soup.find("div", class_="md-table"))
+        self.assertIsNone(soup.find("table"))
 
-    def test_missing_close_marker_is_skipped(self):
-        html = """
-        <p>::: quote-block</p>
-        <blockquote><p>"Text."</p></blockquote>
-        """
-        soup = self._parse(html)
-        # No transformation should have happened
+    def test_missing_quote_text_is_skipped(self):
+        soup = self._parse(self._make_table(""))
         self.assertIsNone(soup.find("p", class_="p-heading--4"))
-        self.assertIsNotNone(soup.find("blockquote"))
 
-    def test_missing_blockquote_is_skipped(self):
+    def test_non_quote_table_is_ignored(self):
         html = """
-        <p>::: quote-block</p>
-        <p>:::</p>
+        <div class="md-table">
+          <table>
+            <thead><tr><th>SOMETHING ELSE</th></tr></thead>
+            <tbody><tr><td>data</td></tr></tbody>
+          </table>
+        </div>
         """
         soup = self._parse(html)
+        # Table should be untouched
         self.assertIsNone(soup.find("p", class_="p-heading--4"))
+        self.assertIsNotNone(soup.find("table"))
 
 
 class TestReplaceImageBlock(unittest.TestCase):
@@ -309,76 +299,79 @@ class TestReplaceImageBlock(unittest.TestCase):
             BeautifulSoup(html, features="lxml")
         )
 
-    def test_basic_image_no_caption(self):
-        html = """
-        <p>::: image-block</p>
-        <p><img src="/img/photo.jpg" alt="photo" width="800" height="450"/></p>
-        <p>:::</p>
+    def _make_table(self, img_url, caption=""):
+        return f"""
+        <div class="md-table">
+          <table>
+            <thead><tr><th>IMAGE BLOCK</th><th></th></tr></thead>
+            <tbody>
+              <tr><td>IMAGE CAPTION (OPTIONAL)</td><td>ASSET LINK</td></tr>
+              <tr>
+                <td>{caption}</td>
+                <td><a href="{img_url}">{img_url}</a></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
         """
-        soup = self._parse(html)
+
+    def test_basic_image_no_caption(self):
+        soup = self._parse(self._make_table("https://assets.ubuntu.com/img/photo.jpg"))
         container = soup.find("div", class_="p-image-container")
         self.assertIsNotNone(container)
         self.assertIn("is-cover", container.get("class", []))
         img = container.find("img")
         self.assertIsNotNone(img)
         self.assertIn("p-image-container__image", img.get("class", []))
-        self.assertEqual(img["src"], "/img/photo.jpg")
-        # height attribute should be stripped
-        self.assertNotIn("height", img.attrs)
-        # No caption
+        self.assertEqual(img["src"], "https://assets.ubuntu.com/img/photo.jpg")
+        # No caption; u-sv3 should be added for spacing
         self.assertIsNone(soup.find("p", class_="u-text--muted"))
+        self.assertIn("u-sv3", container.get("class", []))
 
     def test_image_with_caption(self):
-        html = """
-        <p>::: image-block</p>
-        <p><img src="/img/photo.jpg" alt="" width="800" height="450"/></p>
-        <p><em>This is a caption</em></p>
-        <p>:::</p>
-        """
-        soup = self._parse(html)
+        soup = self._parse(
+            self._make_table("https://assets.ubuntu.com/img/photo.jpg", caption="This is a caption")
+        )
         container = soup.find("div", class_="p-image-container")
         self.assertIsNotNone(container)
         caption_p = soup.find("p", class_="u-text--muted")
         self.assertIsNotNone(caption_p)
         self.assertEqual(caption_p.string, "This is a caption")
+        # u-sv3 should not be added when there is a caption
+        self.assertNotIn("u-sv3", container.get("class", []))
 
-    def test_role_attribute_removed(self):
-        html = """
-        <p>::: image-block</p>
-        <p><img src="/img/photo.jpg" role="presentation" width="100"/></p>
-        <p>:::</p>
-        """
-        soup = self._parse(html)
-        img = soup.find("img")
-        self.assertIsNotNone(img)
-        self.assertNotIn("role", img.attrs)
+    def test_table_removed_after_transform(self):
+        soup = self._parse(self._make_table("https://assets.ubuntu.com/img/photo.jpg"))
+        self.assertIsNone(soup.find("div", class_="md-table"))
+        self.assertIsNone(soup.find("table"))
 
-    def test_markers_removed(self):
+    def test_missing_img_url_is_skipped(self):
         html = """
-        <p>::: image-block</p>
-        <p><img src="/img/photo.jpg" width="100"/></p>
-        <p>:::</p>
-        """
-        soup = self._parse(html)
-        for p in soup.find_all("p"):
-            self.assertNotIn(":::", p.get_text())
-
-    def test_missing_image_is_skipped(self):
-        html = """
-        <p>::: image-block</p>
-        <p>No image here.</p>
-        <p>:::</p>
+        <div class="md-table">
+          <table>
+            <thead><tr><th>IMAGE BLOCK</th><th></th></tr></thead>
+            <tbody>
+              <tr><td>CAPTION</td><td>ASSET LINK</td></tr>
+              <tr><td>caption</td><td></td></tr>
+            </tbody>
+          </table>
+        </div>
         """
         soup = self._parse(html)
         self.assertIsNone(soup.find("div", class_="p-image-container"))
 
-    def test_missing_close_marker_is_skipped(self):
+    def test_non_image_table_is_ignored(self):
         html = """
-        <p>::: image-block</p>
-        <p><img src="/img/photo.jpg" width="100"/></p>
+        <div class="md-table">
+          <table>
+            <thead><tr><th>SOMETHING ELSE</th></tr></thead>
+            <tbody><tr><td>data</td></tr></tbody>
+          </table>
+        </div>
         """
         soup = self._parse(html)
         self.assertIsNone(soup.find("div", class_="p-image-container"))
+        self.assertIsNotNone(soup.find("table"))
 
 
 class TestReplaceHighlightsBlock(unittest.TestCase):
@@ -395,23 +388,31 @@ class TestReplaceHighlightsBlock(unittest.TestCase):
             BeautifulSoup(html, features="lxml")
         )
 
-    def test_basic_highlights_no_title(self):
-        html = """
-        <p>::: highlights-block</p>
-        <ul>
-            <li>Highlight 1</li>
-            <li>Highlight 2</li>
-        </ul>
-        <p>:::</p>
+    def _make_table(self, items, title=""):
+        check = '<img title=":check_mark:" class="emoji"/>'
+        items_html = "".join(f"{check}{item} " for item in items).strip()
+        return f"""
+        <div class="md-table">
+          <table>
+            <thead><tr><th>HIGHLIGHTS BLOCK</th><th></th></tr></thead>
+            <tbody>
+              <tr><td>TITLE</td><td>ITEMS</td></tr>
+              <tr>
+                <td>{title}</td>
+                <td>{items_html}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
         """
-        soup = self._parse(html)
+
+    def test_basic_highlights_no_title(self):
+        soup = self._parse(self._make_table(["Highlight 1", "Highlight 2"]))
         wrapper = soup.find("div", class_="p-list--horizontal-section-wrapper")
         self.assertIsNotNone(wrapper)
         ul = wrapper.find("ul")
         self.assertIsNotNone(ul)
         self.assertIn("p-list--horizontal-section", ul.get("class", []))
-        self.assertNotIn("p-list--divided", ul.get("class", []))
-        self.assertNotIn("is-split", ul.get("class", []))
         lis = ul.find_all("li")
         self.assertEqual(len(lis), 2)
         for li in lis:
@@ -421,14 +422,7 @@ class TestReplaceHighlightsBlock(unittest.TestCase):
         self.assertIsNone(soup.find("p", class_="p-text--small-caps"))
 
     def test_highlights_with_title(self):
-        html = """
-        <p>::: highlights-block<br/><strong>Key features</strong></p>
-        <ul>
-            <li>Feature A</li>
-        </ul>
-        <p>:::</p>
-        """
-        soup = self._parse(html)
+        soup = self._parse(self._make_table(["Feature A"], title="Key features"))
         title_p = soup.find("p", class_="p-text--small-caps")
         self.assertIsNotNone(title_p)
         self.assertEqual(title_p.string, "Key features")
@@ -438,48 +432,197 @@ class TestReplaceHighlightsBlock(unittest.TestCase):
         self.assertIsNotNone(ul)
         self.assertIn("p-list--horizontal-section", ul.get("class", []))
 
-    def test_inner_p_unwrapped(self):
+    def test_items_text_correct(self):
+        soup = self._parse(self._make_table(["Alpha", "Beta", "Gamma"]))
+        lis = soup.find_all("li")
+        texts = [li.get_text(strip=True) for li in lis]
+        self.assertEqual(texts, ["Alpha", "Beta", "Gamma"])
+
+    def test_table_removed_after_transform(self):
+        soup = self._parse(self._make_table(["Item"]))
+        self.assertIsNone(soup.find("div", class_="md-table"))
+        self.assertIsNone(soup.find("table"))
+
+    def test_no_items_is_skipped(self):
         html = """
-        <p>::: highlights-block</p>
-        <ul>
-            <li><p>Wrapped item</p></li>
-        </ul>
-        <p>:::</p>
+        <div class="md-table">
+          <table>
+            <thead><tr><th>HIGHLIGHTS BLOCK</th><th></th></tr></thead>
+            <tbody>
+              <tr><td>TITLE</td><td>ITEMS</td></tr>
+              <tr><td>My title</td><td>No check marks here</td></tr>
+            </tbody>
+          </table>
+        </div>
         """
+        soup = self._parse(html)
+        self.assertIsNone(soup.find("div", class_="p-list--horizontal-section-wrapper"))
+
+    def test_non_highlights_table_is_ignored(self):
+        html = """
+        <div class="md-table">
+          <table>
+            <thead><tr><th>SOMETHING ELSE</th></tr></thead>
+            <tbody><tr><td>data</td></tr></tbody>
+          </table>
+        </div>
+        """
+        soup = self._parse(html)
+        self.assertIsNone(soup.find("div", class_="p-list--horizontal-section-wrapper"))
+        self.assertIsNotNone(soup.find("table"))
+
+
+class TestReplaceStandardTableBlock(unittest.TestCase):
+    def setUp(self):
+        discourse_api = DiscourseAPI("https://base.url", session=MagicMock())
+        self.parser = BaseParser(
+            api=discourse_api,
+            index_topic_id=1,
+            url_prefix="/",
+        )
+
+    def _parse(self, html):
+        return self.parser._replace_standard_table_block(
+            BeautifulSoup(html, features="lxml")
+        )
+
+    def _make_table(self, headers, rows):
+        header_cells = "".join(f"<td>{h}</td>" for h in headers)
+        data_rows = "".join(
+            "<tr>" + "".join(f"<td>{cell}</td>" for cell in row) + "</tr>"
+            for row in rows
+        )
+        marker_ths = "".join("<th></th>" for _ in range(len(headers) - 1))
+        return f"""
+        <div class="md-table">
+          <table>
+            <thead><tr><th>STANDARD TABLE</th>{marker_ths}</tr></thead>
+            <tbody>
+              <tr>{header_cells}</tr>
+              {data_rows}
+            </tbody>
+          </table>
+        </div>
+        """
+
+    def test_md_table_wrapper_removed(self):
+        soup = self._parse(self._make_table(["H1", "H2"], [["R1C1", "R1C2"]]))
+        self.assertIsNone(soup.find("div", class_="md-table"))
+
+    def test_first_row_becomes_thead(self):
+        soup = self._parse(self._make_table(["Col A", "Col B"], [["v1", "v2"]]))
+        table = soup.find("table")
+        self.assertIsNotNone(table)
+        thead = table.find("thead")
+        self.assertIsNotNone(thead)
+        ths = thead.find_all("th")
+        self.assertEqual([th.get_text() for th in ths], ["Col A", "Col B"])
+
+    def test_data_rows_stay_in_tbody(self):
+        soup = self._parse(
+            self._make_table(["H1", "H2"], [["A", "B"], ["C", "D"]])
+        )
+        tbody = soup.find("tbody")
+        self.assertIsNotNone(tbody)
+        rows = tbody.find_all("tr")
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[0].get_text(separator="|", strip=True), "A|B")
+        self.assertEqual(rows[1].get_text(separator="|", strip=True), "C|D")
+
+    def test_marker_thead_removed(self):
+        soup = self._parse(self._make_table(["H1"], [["data"]]))
+        # The original STANDARD TABLE marker th should not appear
+        for th in soup.find_all("th"):
+            self.assertNotIn("STANDARD TABLE", th.get_text())
+
+    def test_non_standard_table_is_ignored(self):
+        html = """
+        <div class="md-table">
+          <table>
+            <thead><tr><th>SOMETHING ELSE</th></tr></thead>
+            <tbody><tr><td>data</td></tr></tbody>
+          </table>
+        </div>
+        """
+        soup = self._parse(html)
+        # md-table wrapper should remain untouched
+        self.assertIsNotNone(soup.find("div", class_="md-table"))
+
+    def test_plain_table_outside_md_table_untouched(self):
+        html = """
+        <table>
+          <thead><tr><th>Normal Header</th></tr></thead>
+          <tbody><tr><td>Normal data</td></tr></tbody>
+        </table>
+        """
+        soup = self._parse(html)
+        table = soup.find("table")
+        self.assertIsNotNone(table)
+        self.assertEqual(table.find("th").get_text(), "Normal Header")
+
+
+class TestReplaceChecklistParagraph(unittest.TestCase):
+    def setUp(self):
+        discourse_api = DiscourseAPI("https://base.url", session=MagicMock())
+        self.parser = BaseParser(
+            api=discourse_api,
+            index_topic_id=1,
+            url_prefix="/",
+        )
+
+    def _parse(self, html):
+        return self.parser._replace_checklist_paragraph(
+            BeautifulSoup(html, features="lxml")
+        )
+
+    CHECK = '<img title=":check_mark:" class="emoji" alt=":check_mark:" src="/images/emoji/twitter/check_mark.png"/>'
+
+    def test_basic_checklist_becomes_ul(self):
+        html = f"<p>{self.CHECK}First item<br/>{self.CHECK}Second item</p>"
+        soup = self._parse(html)
+        self.assertIsNone(soup.find("p"))
+        ul = soup.find("ul")
+        self.assertIsNotNone(ul)
+        self.assertIn("p-list--divided", ul.get("class", []))
+        lis = ul.find_all("li")
+        self.assertEqual(len(lis), 2)
+        self.assertEqual(lis[0].get_text(), "First item")
+        self.assertEqual(lis[1].get_text(), "Second item")
+
+    def test_li_classes(self):
+        html = f"<p>{self.CHECK}Only item</p>"
         soup = self._parse(html)
         li = soup.find("li")
         self.assertIsNotNone(li)
-        # Inner <p> should have been unwrapped
-        self.assertIsNone(li.find("p"))
-        self.assertEqual(li.get_text(strip=True), "Wrapped item")
+        self.assertIn("p-list__item", li.get("class", []))
+        self.assertIn("is-ticked", li.get("class", []))
 
-    def test_markers_removed(self):
-        html = """
-        <p>::: highlights-block</p>
-        <ul><li>Item</li></ul>
-        <p>:::</p>
-        """
+    def test_paragraph_without_checkmarks_is_unchanged(self):
+        html = "<p>Just a normal paragraph</p>"
         soup = self._parse(html)
-        for p in soup.find_all("p"):
-            self.assertNotIn(":::", p.get_text())
+        p = soup.find("p")
+        self.assertIsNotNone(p)
+        self.assertEqual(p.get_text(), "Just a normal paragraph")
 
-    def test_missing_ul_is_skipped(self):
-        html = """
-        <p>::: highlights-block</p>
-        <p>:::</p>
-        """
+    def test_multiple_paragraphs_only_checklist_converted(self):
+        html = (
+            "<p>Normal</p>"
+            f"<p>{self.CHECK}Item A<br/>{self.CHECK}Item B</p>"
+        )
         soup = self._parse(html)
-        self.assertIsNone(soup.find("ul"))
-
-    def test_missing_close_marker_is_skipped(self):
-        html = """
-        <p>::: highlights-block</p>
-        <ul><li>Item</li></ul>
-        """
-        soup = self._parse(html)
+        # Normal paragraph unchanged
+        self.assertIsNotNone(soup.find("p"))
+        # Checklist paragraph converted
         ul = soup.find("ul")
-        # ul should be unchanged — no classes applied
-        self.assertNotIn("p-list--horizontal-section", ul.get("class", []))
+        self.assertIsNotNone(ul)
+        self.assertEqual(len(ul.find_all("li")), 2)
+
+    def test_item_text_is_stripped(self):
+        html = f"<p>{self.CHECK}  Trimmed item  <br/>{self.CHECK}  Also trimmed  </p>"
+        soup = self._parse(html)
+        lis = soup.find_all("li")
+        self.assertEqual(lis[0].get_text(), "Trimmed item")
+        self.assertEqual(lis[1].get_text(), "Also trimmed")
 
 
 class TestDocParser(unittest.TestCase):


### PR DESCRIPTION
## Done

Adds parsers for the following custom blocks:
- blockquotes_block
- highlights_block
- image_block
- standard_table_block

## QA

Examples of all blocks can be seen rendered in [this demo](https://ubuntu-com-16229.demos.haus/engage/test-whitepaper). This is the associated [Discourse post](https://discourse.ubuntu.com/t/test-whitepaper/80037). Which are in turn generated from [this doc](https://docs.google.com/document/d/1hbpsJVO8nhZ4tngLJj0MgQTyffBWClR7QORSHwkIrY0/edit?tab=t.0).

## Issue

Fixes https://warthogs.atlassian.net/browse/WD-35871