### PR TITLE
feat(DiscourseAPI): allow passing multiple tags when querying engage pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### 7.4.0 [24-06-2026]
+**Updated** EngagePages.get_index
+- Now additionaly accepts tags as a list
+
+### 7.3.0 [16-06-2026]
+**Updated** BaseParser
+- Adds the following parsers: blockquotes_block, highlights_block, image_block, standard_table_block, checklist_paragraph
+
 ### 7.2.0 [04-12-2025]
 **Added**
 - Handle apps with both the new (sentry_sdk) and old (raven) Sentry integrations 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,16 @@ Similarly for takeovers, you just need to pass `page_type="takeovers"`.
 - If you want to get all engage pages, which in the case of some sites like jp.ubuntu.com there are not that many, you can pass `limit=-1`
 - Use `MaxLimitError` in the `exceptions.py` to handle excessive limit. By default, it will raise an error when it surpasses 500
 
+## Tag filtering for Engage Pages
+
+`get_index` and the underlying API methods accept a tag parameter that supports filtering by one or more tags using OR logic:
+
+- **Single tag** (string, legacy): `engage_pages.get_index(tag_value="osm")`
+- **Multiple tags, OR logic** (list): `engage_pages.get_index(tag_value=["osm", "gsi"])`
+- **No tag filter**: omit the parameter, pass `None`, or pass an empty list
+
+Tags are matched case-insensitively and duplicates are removed automatically. The same `str | list[str]` interface applies to the `tag` parameter of `DiscourseAPI.get_engage_pages_by_tag()` and the `tag_value` parameter of `DiscourseAPI.get_engage_pages_by_param()`.
+
 
 ## Instructions for Category class usage
 

--- a/canonicalwebteam/discourse/app.py
+++ b/canonicalwebteam/discourse/app.py
@@ -340,7 +340,7 @@ class EngagePages(BaseParser):
 
         params = {k: v for k, v in params.items() if v is not None}
 
-        if tag_value and not value and not second_value:
+        if tag_value and isinstance(tag_value, str) and not value and not second_value:
             list_topics = self.api.get_engage_pages_by_tag(
                 category_id=self.category_id,
                 limit=limit,

--- a/canonicalwebteam/discourse/app.py
+++ b/canonicalwebteam/discourse/app.py
@@ -340,7 +340,12 @@ class EngagePages(BaseParser):
 
         params = {k: v for k, v in params.items() if v is not None}
 
-        if tag_value and isinstance(tag_value, str) and not value and not second_value:
+        if (
+            tag_value
+            and isinstance(tag_value, str)
+            and not value
+            and not second_value
+        ):
             list_topics = self.api.get_engage_pages_by_tag(
                 category_id=self.category_id,
                 limit=limit,

--- a/canonicalwebteam/discourse/models.py
+++ b/canonicalwebteam/discourse/models.py
@@ -1,9 +1,41 @@
+import re
+
 import requests
 from canonicalwebteam.discourse.exceptions import (
     DataExplorerError,
     DiscourseEventsError,
 )
 import json
+
+
+def _normalise_tags(tags):
+    """
+    Accept None, a single tag string, or a list of tag strings.
+    Returns an ordered, whitespace-stripped, case-insensitively de-duped list.
+    """
+    if tags is None:
+        return []
+    if isinstance(tags, str):
+        tags = [tags]
+    seen = set()
+    result = []
+    for t in tags:
+        t = str(t).strip()
+        if t and t.lower() not in seen:
+            seen.add(t.lower())
+            result.append(t)
+    return result
+
+
+def _build_tag_regex(tags):
+    """
+    Build a POSIX regex alternation string from a normalised tag list.
+    Returns None for an empty list (caller should omit the param entirely).
+    A single tag returns '(?:tag)', multiple tags return '(?:tagA|tagB)'.
+    """
+    if not tags:
+        return None
+    return "(?:" + "|".join(re.escape(t) for t in tags) + ")"
 
 
 class DiscourseAPI:
@@ -368,9 +400,12 @@ class DiscourseAPI:
             "offset": str(offset),
         }
 
-        # Tags have to be queried differently due to the way they are stored
-        if tag_value:
-            params_dict["tag_value"] = str(tag_value)
+        # Tags support a single string (legacy) or a list of strings (OR logic).
+        # We serialise into a POSIX regex alternation so the existing ~* clause
+        # in the Data Explorer query handles OR matching without SQL changes.
+        tag_regex = _build_tag_regex(_normalise_tags(tag_value))
+        if tag_regex:
+            params_dict["tag_value"] = tag_regex
 
         if key and value:
             params_dict["keyword"] = key
@@ -422,18 +457,23 @@ class DiscourseAPI:
             "Accept": "application/json",
             "Content-Type": "multipart/form-data;",
         }
-        # See https://discourse.ubuntu.com/admin/plugins/explorer?id=16
+        # See https://discourse.ubuntu.com/admin/plugins/explorer?id=55
         data_explorer_id = 55
 
-        params = (
-            {
-                "params": (
-                    f'{{"category_id":"{category_id}", '
-                    f'"tag":"{tag}", '
-                    f'"limit":"{limit}", "offset":"{offset}"}}'
-                )
-            },
-        )
+        params_dict = {
+            "category_id": str(category_id),
+            "limit": str(limit),
+            "offset": str(offset),
+        }
+
+        # Tags support a single string (legacy) or a list of strings (OR logic).
+        # We serialise into a POSIX regex alternation so the existing ~* clause
+        # in the Data Explorer query handles OR matching without SQL changes.
+        tag_regex = _build_tag_regex(_normalise_tags(tag))
+        if tag_regex:
+            params_dict["tag"] = tag_regex
+
+        params = ({"params": json.dumps(params_dict)},)
 
         response = self.session.post(
             f"{self.base_url}/admin/plugins/explorer/"

--- a/canonicalwebteam/discourse/models.py
+++ b/canonicalwebteam/discourse/models.py
@@ -409,9 +409,9 @@ class DiscourseAPI:
             "offset": str(offset),
         }
 
-        # Tags support a single string (legacy) or a list of strings (OR logic).
-        # We serialise into a POSIX regex alternation so the existing ~* clause
-        # in the Data Explorer query handles OR matching without SQL changes.
+        # Tags support a single string or a list of strings (OR logic)
+        # We serialise into a POSIX regex so the existing ~* clause
+        # in the Data Explorer query handles OR matching without SQL changes
         tag_regex = _build_tag_regex(_normalise_tags(tag_value))
         if tag_regex:
             params_dict["tag_value"] = tag_regex
@@ -480,8 +480,8 @@ class DiscourseAPI:
             "offset": str(offset),
         }
 
-        # Tags support a single string (legacy) or a list of strings (OR logic).
-        # We serialise into a POSIX regex alternation so the existing ~* clause
+        # Tags support a single string or a list of strings (OR logic).
+        # We serialise into a POSIX regex so the existing ~* clause
         # in the Data Explorer query handles OR matching without SQL changes.
         tag_regex = _build_tag_regex(_normalise_tags(tag))
         if tag_regex:

--- a/canonicalwebteam/discourse/models.py
+++ b/canonicalwebteam/discourse/models.py
@@ -443,7 +443,7 @@ class DiscourseAPI:
         result = response.json()
 
         if not result["success"]:
-            raise DataExplorerError(response["errors"][0])
+            raise DataExplorerError(result["errors"][0])
 
         pages = result["rows"]
         return pages
@@ -500,7 +500,7 @@ class DiscourseAPI:
         result = response.json()
 
         if not result["success"]:
-            raise DataExplorerError(response["errors"][0])
+            raise DataExplorerError(result["errors"][0])
 
         pages = result["rows"]
         return pages

--- a/canonicalwebteam/discourse/models.py
+++ b/canonicalwebteam/discourse/models.py
@@ -382,8 +382,17 @@ class DiscourseAPI:
         -source-mano
 
         Args:
+        - category_id [int]: The category ID
+        - key [str]: Metadata key to filter by
+        - value [str]: Metadata value to filter by
         - limit [int]: 50 by default, also set in data explorer
         - offset [int]: 0 by default (first page)
+        - second_key [str]: Second metadata key to filter by
+        - second_value [str]: Second metadata value to filter by
+        - tag_value [str | list[str]]: Filter by tag(s). Accepts either a
+          single tag string (e.g. "osm") or a list of tag strings for OR
+          matching (e.g. ["osm", "gsi"]). An empty list or None returns
+          all pages with no tag filter.
         """
         self._require_authentication()
 
@@ -441,13 +450,18 @@ class DiscourseAPI:
 
     def get_engage_pages_by_tag(self, category_id, tag, limit=50, offset=0):
         """
-        Uses data-explorer to query engage pages
+        Uses data-explorer to query engage pages by tag.
 
         Same functionality and return values as
         get_engage_pages_by_param, but specifically
-        for querying by tags
+        for querying by tags.
 
         Args:
+        - category_id [int]: The category ID
+        - tag [str | list[str]]: Filter by tag(s). Accepts either a single
+          tag string (e.g. "osm") or a list of tag strings for OR matching
+          (e.g. ["osm", "gsi"]). An empty list or None returns all pages
+          with no tag filter.
         - limit [int]: 50 by default, also set in data explorer
         - offset [int]: 0 by default (first page)
         """

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse",
-    version="7.3.0",
+    version="7.4.0",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical/canonicalwebteam.discourse",

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -116,11 +116,11 @@ class TestGetEngagePagesByParamTagValue(unittest.TestCase):
         with unittest.mock.patch.object(
             api.session, "post", return_value=_mock_post_response()
         ) as mock_post:
-            api.get_engage_pages_by_param(
-                category_id=51, tag_value=tag_value
-            )
+            api.get_engage_pages_by_param(category_id=51, tag_value=tag_value)
             call_kwargs = mock_post.call_args
-            sent_data = call_kwargs[1]["data"] if call_kwargs[1] else call_kwargs[0][1]
+            sent_data = (
+                call_kwargs[1]["data"] if call_kwargs[1] else call_kwargs[0][1]
+            )
             return json.loads(sent_data["params"])
 
     def test_legacy_single_string_becomes_regex(self):
@@ -170,7 +170,9 @@ class TestGetEngagePagesByTagMultiTag(unittest.TestCase):
         ) as mock_post:
             api.get_engage_pages_by_tag(category_id=51, tag=tag)
             call_kwargs = mock_post.call_args
-            sent_data = call_kwargs[1]["data"] if call_kwargs[1] else call_kwargs[0][1]
+            sent_data = (
+                call_kwargs[1]["data"] if call_kwargs[1] else call_kwargs[0][1]
+            )
             return json.loads(sent_data["params"])
 
     def test_legacy_single_string_becomes_regex(self):
@@ -201,37 +203,6 @@ class TestGetEngagePagesByTagMultiTag(unittest.TestCase):
     def test_three_tags(self):
         params = self._call_and_capture_params(["osm", "gsi", "cloud"])
         self.assertEqual(params["tag"], "(?:osm|gsi|cloud)")
-
-
-if __name__ == "__main__":
-    unittest.main()
-
-
-
-class TestDiscourseAPI(unittest.TestCase):
-    def setUp(self):
-        httpretty.enable()
-        register_uris()
-
-        self.api = DiscourseAPI(
-            base_url="https://discourse.example.com",
-            session=requests.Session(),
-        )
-
-    def test_get_topic(self):
-        """
-        Check the DiscourseAPI object can get a topic by its ID
-        """
-
-        topic = self.api.get_topic(34)
-
-        self.assertEqual(topic["id"], 34)
-        self.assertEqual(topic["title"], "An index page")
-
-    def test_require_authentication_raises_error_without_credentials(self):
-        with self.assertRaises(ValueError) as context:
-            self.api._require_authentication()
-        self.assertIn("API authentication required", str(context.exception))
 
 
 if __name__ == "__main__":

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,9 +1,211 @@
+import json
 import unittest
+import unittest.mock
 import httpretty
 import requests
 
-from canonicalwebteam.discourse.models import DiscourseAPI
+from canonicalwebteam.discourse.models import (
+    DiscourseAPI,
+    _normalise_tags,
+    _build_tag_regex,
+)
 from tests.fixtures.forum_mock import register_uris
+
+
+class TestDiscourseAPI(unittest.TestCase):
+    def setUp(self):
+        httpretty.enable()
+        register_uris()
+
+        self.api = DiscourseAPI(
+            base_url="https://discourse.example.com",
+            session=requests.Session(),
+        )
+
+    def test_get_topic(self):
+        """
+        Check the DiscourseAPI object can get a topic by its ID
+        """
+
+        topic = self.api.get_topic(34)
+
+        self.assertEqual(topic["id"], 34)
+        self.assertEqual(topic["title"], "An index page")
+
+    def test_require_authentication_raises_error_without_credentials(self):
+        with self.assertRaises(ValueError) as context:
+            self.api._require_authentication()
+        self.assertIn("API authentication required", str(context.exception))
+
+
+class TestNormaliseTags(unittest.TestCase):
+    def test_none_returns_empty_list(self):
+        self.assertEqual(_normalise_tags(None), [])
+
+    def test_empty_string_returns_empty_list(self):
+        self.assertEqual(_normalise_tags(""), [])
+
+    def test_single_string_wrapped_in_list(self):
+        self.assertEqual(_normalise_tags("osm"), ["osm"])
+
+    def test_list_passthrough(self):
+        self.assertEqual(_normalise_tags(["osm", "gsi"]), ["osm", "gsi"])
+
+    def test_strips_whitespace(self):
+        self.assertEqual(_normalise_tags(["  osm  ", " gsi"]), ["osm", "gsi"])
+
+    def test_case_insensitive_dedup_preserves_first(self):
+        self.assertEqual(_normalise_tags(["osm", "OSM", "Osm"]), ["osm"])
+
+    def test_empty_list_returns_empty(self):
+        self.assertEqual(_normalise_tags([]), [])
+
+    def test_empty_strings_in_list_are_dropped(self):
+        self.assertEqual(_normalise_tags(["osm", "", "  "]), ["osm"])
+
+
+class TestBuildTagRegex(unittest.TestCase):
+    def test_empty_list_returns_none(self):
+        self.assertIsNone(_build_tag_regex([]))
+
+    def test_single_tag(self):
+        self.assertEqual(_build_tag_regex(["osm"]), "(?:osm)")
+
+    def test_multiple_tags_joined_with_pipe(self):
+        self.assertEqual(_build_tag_regex(["osm", "gsi"]), "(?:osm|gsi)")
+
+    def test_regex_special_chars_are_escaped(self):
+        self.assertEqual(_build_tag_regex(["c++"]), r"(?:c\+\+)")
+
+    def test_three_tags(self):
+        self.assertEqual(
+            _build_tag_regex(["osm", "gsi", "cloud"]), "(?:osm|gsi|cloud)"
+        )
+
+
+def _make_authenticated_api():
+    session = requests.Session()
+    return DiscourseAPI(
+        base_url="https://discourse.example.com",
+        session=session,
+        api_key="fake-key",
+        api_username="fake-user",
+    )
+
+
+def _mock_post_response(rows=None):
+    mock_response = unittest.mock.Mock()
+    mock_response.raise_for_status = unittest.mock.Mock()
+    mock_response.json.return_value = {
+        "success": True,
+        "errors": [],
+        "rows": rows or [],
+    }
+    return mock_response
+
+
+class TestGetEngagePagesByParamTagValue(unittest.TestCase):
+    """
+    Unit tests for the tag_value parameter of get_engage_pages_by_param.
+    All HTTP calls are mocked; we assert on the serialised params sent to
+    the Data Explorer endpoint.
+    """
+
+    def _call_and_capture_params(self, tag_value):
+        api = _make_authenticated_api()
+        with unittest.mock.patch.object(
+            api.session, "post", return_value=_mock_post_response()
+        ) as mock_post:
+            api.get_engage_pages_by_param(
+                category_id=51, tag_value=tag_value
+            )
+            call_kwargs = mock_post.call_args
+            sent_data = call_kwargs[1]["data"] if call_kwargs[1] else call_kwargs[0][1]
+            return json.loads(sent_data["params"])
+
+    def test_legacy_single_string_becomes_regex(self):
+        params = self._call_and_capture_params("osm")
+        self.assertEqual(params["tag_value"], "(?:osm)")
+
+    def test_multi_tag_list_becomes_alternation(self):
+        params = self._call_and_capture_params(["osm", "gsi"])
+        self.assertEqual(params["tag_value"], "(?:osm|gsi)")
+
+    def test_empty_list_omits_tag_value(self):
+        params = self._call_and_capture_params([])
+        self.assertNotIn("tag_value", params)
+
+    def test_none_omits_tag_value(self):
+        params = self._call_and_capture_params(None)
+        self.assertNotIn("tag_value", params)
+
+    def test_duplicate_tags_are_deduped(self):
+        params = self._call_and_capture_params(["osm", "OSM", "osm"])
+        self.assertEqual(params["tag_value"], "(?:osm)")
+
+    def test_single_item_list_matches_legacy_string(self):
+        params_list = self._call_and_capture_params(["osm"])
+        params_str = self._call_and_capture_params("osm")
+        self.assertEqual(params_list["tag_value"], params_str["tag_value"])
+
+    def test_regex_special_chars_escaped(self):
+        params = self._call_and_capture_params(["c++"])
+        self.assertEqual(params["tag_value"], r"(?:c\+\+)")
+
+    def test_three_tags(self):
+        params = self._call_and_capture_params(["osm", "gsi", "cloud"])
+        self.assertEqual(params["tag_value"], "(?:osm|gsi|cloud)")
+
+
+class TestGetEngagePagesByTagMultiTag(unittest.TestCase):
+    """
+    Unit tests for the tag parameter of get_engage_pages_by_tag.
+    Mirrors TestGetEngagePagesByParamTagValue but exercises query 55.
+    """
+
+    def _call_and_capture_params(self, tag):
+        api = _make_authenticated_api()
+        with unittest.mock.patch.object(
+            api.session, "post", return_value=_mock_post_response()
+        ) as mock_post:
+            api.get_engage_pages_by_tag(category_id=51, tag=tag)
+            call_kwargs = mock_post.call_args
+            sent_data = call_kwargs[1]["data"] if call_kwargs[1] else call_kwargs[0][1]
+            return json.loads(sent_data["params"])
+
+    def test_legacy_single_string_becomes_regex(self):
+        params = self._call_and_capture_params("osm")
+        self.assertEqual(params["tag"], "(?:osm)")
+
+    def test_multi_tag_list_becomes_alternation(self):
+        params = self._call_and_capture_params(["osm", "gsi"])
+        self.assertEqual(params["tag"], "(?:osm|gsi)")
+
+    def test_empty_list_omits_tag(self):
+        params = self._call_and_capture_params([])
+        self.assertNotIn("tag", params)
+
+    def test_duplicate_tags_are_deduped(self):
+        params = self._call_and_capture_params(["osm", "OSM", "osm"])
+        self.assertEqual(params["tag"], "(?:osm)")
+
+    def test_single_item_list_matches_legacy_string(self):
+        params_list = self._call_and_capture_params(["osm"])
+        params_str = self._call_and_capture_params("osm")
+        self.assertEqual(params_list["tag"], params_str["tag"])
+
+    def test_regex_special_chars_escaped(self):
+        params = self._call_and_capture_params(["c++"])
+        self.assertEqual(params["tag"], r"(?:c\+\+)")
+
+    def test_three_tags(self):
+        params = self._call_and_capture_params(["osm", "gsi", "cloud"])
+        self.assertEqual(params["tag"], "(?:osm|gsi|cloud)")
+
+
+if __name__ == "__main__":
+    unittest.main()
+
 
 
 class TestDiscourseAPI(unittest.TestCase):


### PR DESCRIPTION
## Done

- Adds ability to pass multiple tags
- extends already existing topic query
- adds `_normalise_tags` and `_build_tag_regex` helper function
- adds tests for aforementioned features
- some fly-by cleanup

## QA

- Open this conveniently setup [demo](https://ubuntu-com-16493.demos.haus/engage)
- Check that when you filter with multiple tags, the results contain posts with the selected tags (OR selection)

## Fixes

Issue https://warthogs.atlassian.net/browse/WD-37305