### PR TITLE
fix: unwrap p elements inside li elements when parsing lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### 7.5.0 [25-06-2026]
 **Updated** BaseParser._replace_lists
-- Unwrap `<p>` eles nested inside `<li>` eles
+- Unwrap `<p>` elements nested inside `<li>` elements
 
 ### 7.4.0 [24-06-2026]
 **Updated** EngagePages.get_index

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 7.5.0 [25-06-2026]
+**Updated** BaseParser._replace_lists
+- Unwrap `<p>` eles nested inside `<li>` eles
+
 ### 7.4.0 [24-06-2026]
 **Updated** EngagePages.get_index
 - Now additionaly accepts tags as a list

--- a/canonicalwebteam/discourse/parsers/base_parser.py
+++ b/canonicalwebteam/discourse/parsers/base_parser.py
@@ -889,6 +889,8 @@ class BaseParser:
             for li in ul.find_all("li", recursive=False):
                 if "p-list__item" in li.get("class", []):
                     continue
+                for p in li.find_all("p"):
+                    p.unwrap()
                 checkbox = li.find(
                     "span",
                     class_=lambda c: c
@@ -914,6 +916,8 @@ class BaseParser:
             for li in ol.find_all("li", recursive=False):
                 if "p-list__item" in li.get("class", []):
                     continue
+                for p in li.find_all("p"):
+                    p.unwrap()
                 li["class"] = li.get("class", []) + ["p-list__item"]
 
         return soup

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse",
-    version="7.4.0",
+    version="7.5.0",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical/canonicalwebteam.discourse",


### PR DESCRIPTION
## Problem statement

In some cases `<p>` elements were being nested inside `<li>` elements resulting in broken visuals
<img width="1008" height="54" alt="image" src="https://github.com/user-attachments/assets/b814604a-88ee-4125-8a02-374dd0e06a6a" />

## Done

- unwraps any nested `<p>` elements when parsing lists

## QA

- See the list in [this demo](https://ubuntu-com-16229.demos.haus/engage/managed-kubeflow-microsoft-azure) is broken
- See the list in [this demo](https://ubuntu-com-16508.demos.haus/engage/managed-kubeflow-microsoft-azure) is not