### PR TITLE
feat: add response caching and rate-limit handling to DiscourseAPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### 7.6.0 [04-07-2026]
 **Added** DiscourseAPI response caching and rate-limit handling
 - New optional `cache` parameter on `DiscourseAPI`: pass a `ResponseCache` to cache responses per request signature, serve stale data while Discourse errors, and bound retries during outages
-- New `ResponseCache` (TTL + short negative TTL, expired-then-oldest eviction, per-key error backoff)
+- New `ResponseCache` (TTL + short negative TTL, expired-then-oldest eviction, per-key error backoff, and a per-instance circuit breaker: a 429 opens a cooldown for every key so workers stop hammering Discourse until it recovers)
 - New `RateLimitedError` (carries `retry_after`) raised instead of a bare `HTTPError` when Discourse returns 429 and no cached response is available
 - `check_for_topic_updates`/`check_for_category_updates` invalidate the corresponding cache entries when an update is detected
 - Behaviour is unchanged when `cache` is not passed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### 7.6.0 [04-07-2026]
+**Added** DiscourseAPI response caching and rate-limit handling
+- New optional `cache` parameter on `DiscourseAPI`: pass a `ResponseCache` to cache responses per request signature, serve stale data while Discourse errors, and bound retries during outages
+- New `ResponseCache` (TTL + short negative TTL, expired-then-oldest eviction, per-key error backoff)
+- New `RateLimitedError` (carries `retry_after`) raised instead of a bare `HTTPError` when Discourse returns 429 and no cached response is available
+- `check_for_topic_updates`/`check_for_category_updates` invalidate the corresponding cache entries when an update is detected
+- Behaviour is unchanged when `cache` is not passed
+
 ### 7.5.0 [25-06-2026]
 **Updated** BaseParser._replace_lists
 - Unwrap `<p>` elements nested inside `<li>` elements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 - New `ResponseCache` (TTL + short negative TTL, expired-then-oldest eviction, per-key error backoff, and a per-instance circuit breaker: a 429 opens a cooldown for every key so workers stop hammering Discourse until it recovers)
 - New `RateLimitedError` (carries `retry_after`) raised instead of a bare `HTTPError` when Discourse returns 429 and no cached response is available
 - `check_for_topic_updates`/`check_for_category_updates` invalidate the corresponding cache entries when an update is detected
+- Revoked content (403/404/410 upstream) drops its cache entry instead of being served stale
+- Freshness probes respect the circuit breaker, and probe 429s open it
+- The packaged view classes translate `RateLimitedError` into a 503 with `Retry-After`
 - Behaviour is unchanged when `cache` is not passed
 
 ### 7.5.0 [25-06-2026]

--- a/README.md
+++ b/README.md
@@ -37,6 +37,59 @@ discourse.init_app(app)
 
 Once this is added you will need to add the file `document.html` to your template folder.
 
+## Response caching and rate-limit handling (optional)
+
+Discourse rate-limits API credentials (HTTP 429). Sites that fetch content
+from Discourse on every page render will exhaust that limit whenever
+crawlers cause bursts of traffic, turning every Discourse-backed page into
+a 500. Passing a `ResponseCache` to `DiscourseAPI` bounds how often each
+unique request reaches Discourse, serves the last known data while
+Discourse is erroring, and raises a typed `RateLimitedError` (instead of a
+bare `HTTPError`) when Discourse returns 429 and nothing is cached.
+
+```python
+from canonicalwebteam.discourse import DiscourseAPI, ResponseCache
+
+api = DiscourseAPI(
+    base_url="https://forum.example.com/",
+    session=session,
+    api_key=DISCOURSE_API_KEY,
+    api_username=DISCOURSE_API_USERNAME,
+    cache=ResponseCache(
+        ttl=300,  # seconds a successful response is served from memory
+        negative_ttl=60,  # empty results expire faster
+        max_size=2000,  # per-worker entry cap
+        error_retry=30,  # retry a failing Discourse at most this often
+    ),
+)
+```
+
+Consumers decide what a rate limit means for them, typically a 503 with
+`Retry-After` rather than a 500:
+
+```python
+from canonicalwebteam.discourse import RateLimitedError
+
+
+@app.errorhandler(RateLimitedError)
+def discourse_rate_limited(error):
+    response = flask.make_response(
+        flask.render_template("503.html"), 503
+    )
+    response.headers["Retry-After"] = str(error.retry_after)
+    return response
+```
+
+Notes:
+
+- The cache is per-process: each worker warms independently, so a page
+  costs at most one Discourse call per worker per `ttl` seconds.
+- `check_for_topic_updates` and `check_for_category_updates` invalidate
+  the corresponding cache entries when they detect an update, so edited
+  content is re-fetched immediately rather than waiting out the TTL.
+- When `cache` is not passed, behaviour is exactly as before — the
+  feature is fully opt-in.
+
 ## Local development
 
 For local development, it's best to test this module with one of our website projects like [ubuntu.com](https://github.com/canonical-web-and-design/ubuntu.com/). For more information, follow [this guide (internal only)](https://discourse.canonical.com/t/how-to-run-our-python-modules-for-local-development/308).

--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ Notes:
 
 - The cache is per-process: each worker warms independently, so a page
   costs at most one Discourse call per worker per `ttl` seconds.
+- A 429 opens a circuit breaker on the whole `ResponseCache` (one cache
+  maps to one API key, i.e. one quota): until the cooldown expires, all
+  keys serve stale data or raise `RateLimitedError` without contacting
+  Discourse, honouring Discourse's `Retry-After` header.
 - `check_for_topic_updates` and `check_for_category_updates` invalidate
   the corresponding cache entries when they detect an update, so edited
   content is re-fetched immediately rather than waiting out the TTL.

--- a/canonicalwebteam/discourse/__init__.py
+++ b/canonicalwebteam/discourse/__init__.py
@@ -5,6 +5,8 @@ from canonicalwebteam.discourse.app import (  # noqa
     Category,  # noqa
     Events,  # noqa
 )
+from canonicalwebteam.discourse.cache import ResponseCache  # noqa
+from canonicalwebteam.discourse.exceptions import RateLimitedError  # noqa
 from canonicalwebteam.discourse.models import DiscourseAPI  # noqa
 from canonicalwebteam.discourse.parsers import (  # noqa
     DocParser,  # noqa

--- a/canonicalwebteam/discourse/app.py
+++ b/canonicalwebteam/discourse/app.py
@@ -2,8 +2,11 @@ import flask
 import html
 from requests.exceptions import HTTPError
 
+from werkzeug.exceptions import ServiceUnavailable
+
 from canonicalwebteam.discourse.exceptions import (
     PathNotFoundError,
+    RateLimitedError,
     RedirectFoundError,
     MetadataError,
     MarkdownError,
@@ -180,6 +183,10 @@ class Docs(Discourse):
 
                 try:
                     topic = self.parser.api.get_topic(topic_id)
+                except RateLimitedError as rate_error:
+                    raise ServiceUnavailable(
+                        retry_after=rate_error.retry_after
+                    ) from rate_error
                 except HTTPError as http_error:
                     return flask.abort(http_error.response.status_code)
 
@@ -259,6 +266,10 @@ class Tutorials(Discourse):
 
                 try:
                     topic = self.parser.api.get_topic(topic_id)
+                except RateLimitedError as rate_error:
+                    raise ServiceUnavailable(
+                        retry_after=rate_error.retry_after
+                    ) from rate_error
                 except HTTPError as http_error:
                     return flask.abort(http_error.response.status_code)
 
@@ -775,6 +786,10 @@ class Category:
 
             try:
                 topic = self.parser.api.get_topic(topic_id)
+            except RateLimitedError as rate_error:
+                raise ServiceUnavailable(
+                    retry_after=rate_error.retry_after
+                ) from rate_error
             except HTTPError as http_error:
                 return flask.abort(http_error.response.status_code)
 
@@ -788,6 +803,10 @@ class Category:
         """
         try:
             topic = self.parser.api.get_topic(topic_id)
+        except RateLimitedError as rate_error:
+            raise ServiceUnavailable(
+                retry_after=rate_error.retry_after
+            ) from rate_error
         except HTTPError as http_error:
             return flask.abort(http_error.response.status_code)
 

--- a/canonicalwebteam/discourse/cache.py
+++ b/canonicalwebteam/discourse/cache.py
@@ -1,0 +1,137 @@
+"""In-process response cache with stale-on-error fallback for DiscourseAPI.
+
+Discourse rate-limits API credentials (HTTP 429). Sites that fetch content
+from Discourse on every page render exhaust that limit whenever crawlers
+generate bursts of cache-miss traffic, turning every Discourse-backed page
+into a 500.
+
+ResponseCache bounds how often each unique request reaches Discourse:
+fresh responses are served from memory, upstream errors are absorbed by
+serving the last known value, and a rate limit with no fallback surfaces
+as a typed RateLimitedError carrying Retry-After so consumers can return
+a 503 instead of a 500.
+
+The cache is per-process: each worker warms independently, so with the
+default ttl a page costs at most one Discourse call per worker per five
+minutes, regardless of traffic volume.
+"""
+
+# Standard library
+import threading
+import time
+
+# Packages
+from requests.exceptions import RequestException
+
+# Local
+from canonicalwebteam.discourse.exceptions import RateLimitedError
+
+DEFAULT_RETRY_AFTER = 60
+MAX_RETRY_AFTER = 600
+
+
+def _retry_after_from(response):
+    value = response.headers.get("Retry-After", "").strip()
+    if value.isdigit():
+        return max(1, min(int(value), MAX_RETRY_AFTER))
+    return DEFAULT_RETRY_AFTER
+
+
+class ResponseCache:
+    """
+    A TTL response cache with stale-on-error fallback.
+
+    @param ttl: seconds a successful response is served from memory
+    @param negative_ttl: seconds an empty response (None/[]/{}) is served;
+        kept short so newly published content appears quickly
+    @param max_size: entry cap; expired entries are dropped first, then
+        the oldest half, so hot entries keep their stale fallback even
+        under floods of unique keys
+    @param error_retry: while Discourse is erroring, a stale entry is
+        retried at most this often (seconds)
+    """
+
+    def __init__(
+        self, ttl=300, negative_ttl=60, max_size=2000, error_retry=30
+    ):
+        self.ttl = ttl
+        self.negative_ttl = negative_ttl
+        self.max_size = max_size
+        self.error_retry = error_retry
+        # key -> (timestamp, value)
+        self._entries = {}
+        self._lock = threading.Lock()
+
+    def _ttl_for(self, value):
+        if value:
+            return self.ttl
+        return self.negative_ttl
+
+    def _is_fresh(self, entry):
+        timestamp, value = entry
+        return time.monotonic() - timestamp < self._ttl_for(value)
+
+    def _evict(self):
+        """
+        Make room without wiping hot entries: drop expired entries first,
+        then the oldest half. Call with the lock held.
+        """
+        for key in [
+            k
+            for k, entry in self._entries.items()
+            if not self._is_fresh(entry)
+        ]:
+            self._entries.pop(key, None)
+        if len(self._entries) >= self.max_size:
+            oldest = sorted(self._entries.items(), key=lambda item: item[1][0])
+            for key, _ in oldest[: self.max_size // 2]:
+                self._entries.pop(key, None)
+
+    def get(self, key, fetch):
+        """
+        Return the cached value for ``key``, refreshing via ``fetch()``
+        when stale. On upstream failure the stale value is served and
+        re-stamped so Discourse is retried at most every ``error_retry``
+        seconds; an uncacheable 429 raises RateLimitedError.
+        """
+        entry = self._entries.get(key)
+        if entry and self._is_fresh(entry):
+            return entry[1]
+
+        try:
+            value = fetch()
+        except RequestException as error:
+            if entry:
+                # Serve stale, and hold off retrying Discourse so error
+                # storms stop consuming the shared API rate limit
+                backoff_timestamp = (
+                    time.monotonic()
+                    - self._ttl_for(entry[1])
+                    + self.error_retry
+                )
+                with self._lock:
+                    self._entries[key] = (backoff_timestamp, entry[1])
+                return entry[1]
+            response = getattr(error, "response", None)
+            if response is not None and response.status_code == 429:
+                raise RateLimitedError(
+                    retry_after=_retry_after_from(response)
+                ) from error
+            raise
+
+        with self._lock:
+            if len(self._entries) >= self.max_size:
+                self._evict()
+            self._entries[key] = (time.monotonic(), value)
+        return value
+
+    def invalidate(self, *key_prefix):
+        """
+        Drop the entry with this exact key, or every entry whose tuple
+        key starts with the given prefix.
+        """
+        with self._lock:
+            for key in [
+                k for k in self._entries if k[: len(key_prefix)] == key_prefix
+            ]:
+                self._entries.pop(key, None)

--- a/canonicalwebteam/discourse/cache.py
+++ b/canonicalwebteam/discourse/cache.py
@@ -61,6 +61,30 @@ class ResponseCache:
         # key -> (timestamp, value)
         self._entries = {}
         self._lock = threading.Lock()
+        # Circuit breaker: one ResponseCache maps to one DiscourseAPI
+        # instance (one API key, one quota), so a 429 anywhere opens a
+        # cooldown for every key until Discourse recovers
+        self._cooldown_until = 0.0
+
+    def _open_cooldown(self, response):
+        delay = max(_retry_after_from(response), DEFAULT_RETRY_AFTER)
+        self._cooldown_until = time.monotonic() + delay
+
+    def _remaining_cooldown(self):
+        return max(1, int(self._cooldown_until - time.monotonic()))
+
+    def _serve_stale(self, key, entry):
+        """
+        Serve a stale entry, re-stamped so the next retry against a
+        failing Discourse happens after ``error_retry`` seconds instead
+        of on every request
+        """
+        backoff_timestamp = (
+            time.monotonic() - self._ttl_for(entry[1]) + self.error_retry
+        )
+        with self._lock:
+            self._entries[key] = (backoff_timestamp, entry[1])
+        return entry[1]
 
     def _ttl_for(self, value):
         if value:
@@ -98,25 +122,25 @@ class ResponseCache:
         if entry and self._is_fresh(entry):
             return entry[1]
 
+        if time.monotonic() < self._cooldown_until:
+            if entry:
+                return entry[1]
+            raise RateLimitedError(retry_after=self._remaining_cooldown())
+
         try:
             value = fetch()
         except RequestException as error:
-            if entry:
-                # Serve stale, and hold off retrying Discourse so error
-                # storms stop consuming the shared API rate limit
-                backoff_timestamp = (
-                    time.monotonic()
-                    - self._ttl_for(entry[1])
-                    + self.error_retry
-                )
-                with self._lock:
-                    self._entries[key] = (backoff_timestamp, entry[1])
-                return entry[1]
             response = getattr(error, "response", None)
             if response is not None and response.status_code == 429:
+                self._open_cooldown(response)
+                if entry:
+                    return self._serve_stale(key, entry)
                 raise RateLimitedError(
                     retry_after=_retry_after_from(response)
                 ) from error
+            if entry:
+                # Serve stale so upstream errors don't break pages
+                return self._serve_stale(key, entry)
             raise
 
         with self._lock:

--- a/canonicalwebteam/discourse/cache.py
+++ b/canonicalwebteam/discourse/cache.py
@@ -30,10 +30,16 @@ DEFAULT_RETRY_AFTER = 60
 MAX_RETRY_AFTER = 600
 
 
+# Statuses that mean the content is authoritatively gone: serving a
+# stale copy would keep revoked (deleted/private) content public
+REVOKED_STATUSES = (403, 404, 410)
+
+
 def _retry_after_from(response):
     value = response.headers.get("Retry-After", "").strip()
-    if value.isdigit():
-        return max(1, min(int(value), MAX_RETRY_AFTER))
+    if value.isdecimal():
+        value = min(int(value), MAX_RETRY_AFTER)
+        return max(value, DEFAULT_RETRY_AFTER)
     return DEFAULT_RETRY_AFTER
 
 
@@ -73,6 +79,22 @@ class ResponseCache:
     def _remaining_cooldown(self):
         return max(1, int(self._cooldown_until - time.monotonic()))
 
+    def cooldown_remaining(self):
+        """
+        Seconds left on an open circuit breaker, 0 when closed. Lets
+        callers with uncached requests (e.g. freshness probes) respect
+        the cooldown too.
+        """
+        if time.monotonic() < self._cooldown_until:
+            return self._remaining_cooldown()
+        return 0
+
+    def report_rate_limit(self, response):
+        """
+        Open the circuit breaker for a 429 observed outside the cache
+        """
+        self._open_cooldown(response)
+
     def _serve_stale(self, key, entry):
         """
         Serve a stale entry, re-stamped so the next retry against a
@@ -108,7 +130,7 @@ class ResponseCache:
             self._entries.pop(key, None)
         if len(self._entries) >= self.max_size:
             oldest = sorted(self._entries.items(), key=lambda item: item[1][0])
-            for key, _ in oldest[: self.max_size // 2]:
+            for key, _ in oldest[: max(1, self.max_size // 2)]:
                 self._entries.pop(key, None)
 
     def get(self, key, fetch):
@@ -131,15 +153,23 @@ class ResponseCache:
             value = fetch()
         except RequestException as error:
             response = getattr(error, "response", None)
-            if response is not None and response.status_code == 429:
+            status = None if response is None else response.status_code
+            if status == 429:
                 self._open_cooldown(response)
                 if entry:
                     return self._serve_stale(key, entry)
                 raise RateLimitedError(
                     retry_after=_retry_after_from(response)
                 ) from error
+            if status in REVOKED_STATUSES:
+                # The content is gone or no longer public: drop the
+                # cached copy instead of serving it stale
+                with self._lock:
+                    self._entries.pop(key, None)
+                raise
             if entry:
-                # Serve stale so upstream errors don't break pages
+                # Serve stale so transient upstream errors don't
+                # break pages
                 return self._serve_stale(key, entry)
             raise
 
@@ -152,7 +182,8 @@ class ResponseCache:
     def invalidate(self, *key_prefix):
         """
         Drop the entry with this exact key, or every entry whose tuple
-        key starts with the given prefix.
+        key starts with the given prefix. Calling with no arguments
+        clears the whole cache.
         """
         with self._lock:
             for key in [

--- a/canonicalwebteam/discourse/exceptions.py
+++ b/canonicalwebteam/discourse/exceptions.py
@@ -125,3 +125,16 @@ class MaxLimitError(Exception):
     """
 
     pass
+
+
+class RateLimitedError(Exception):
+    """
+    Discourse is rate-limiting our API credentials (HTTP 429) and no
+    cached response was available to serve instead.
+
+    Consumers should surface this as a 503 with the given Retry-After.
+    """
+
+    def __init__(self, message=None, retry_after=60):
+        self.retry_after = retry_after
+        super().__init__(message or "Discourse API rate limit exceeded")

--- a/canonicalwebteam/discourse/models.py
+++ b/canonicalwebteam/discourse/models.py
@@ -4,8 +4,17 @@ import requests
 from canonicalwebteam.discourse.exceptions import (
     DataExplorerError,
     DiscourseEventsError,
+    RateLimitedError,
 )
 import json
+
+# Cache key prefixes, shared between the fetch sites and the
+# invalidation sites in check_for_topic_updates /
+# check_for_category_updates -- keep them in sync
+_KEY_TOPIC = "topic"
+_KEY_CATEGORY = "category"
+_KEY_TOPIC_LIST = "topic_list"
+_KEY_EVENTS = "events"
 
 
 def _normalise_tags(tags):
@@ -97,6 +106,32 @@ class DiscourseAPI:
             return fetch()
         return self.cache.get(key, fetch)
 
+    def _breaker_guard(self):
+        """
+        Short-circuit uncached requests (freshness probes) while the
+        circuit breaker is open, so they stop consuming the exhausted
+        rate limit too
+        """
+        if self.cache is not None:
+            remaining = self.cache.cooldown_remaining()
+            if remaining:
+                raise RateLimitedError(retry_after=remaining)
+
+    def _raise_for_status_with_breaker(self, response):
+        """
+        raise_for_status, but a 429 opens the circuit breaker and
+        surfaces as RateLimitedError when a cache is configured
+        """
+        try:
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as error:
+            if self.cache is not None and response.status_code == 429:
+                self.cache.report_rate_limit(response)
+                raise RateLimitedError(
+                    retry_after=self.cache.cooldown_remaining()
+                ) from error
+            raise
+
     def get_topic(self, topic_id):
         """
         Retrieve topic object by path
@@ -108,7 +143,7 @@ class DiscourseAPI:
             return response.json()
 
         # str() so int and str topic ids share one cache entry
-        return self._cached(("topic", str(topic_id)), fetch)
+        return self._cached((_KEY_TOPIC, str(topic_id)), fetch)
 
     def get_topics(self, topic_ids):
         """
@@ -144,7 +179,10 @@ class DiscourseAPI:
 
             return result["rows"]
 
-        return self._cached(("topics", topics), fetch)
+        # Sorted so differently-ordered id lists share one cache entry
+        return self._cached(
+            ("topics", ",".join(sorted(topics.split(",")))), fetch
+        )
 
     def get_topics_category(self, category_id, page=0):
         """
@@ -158,7 +196,9 @@ class DiscourseAPI:
             response.raise_for_status()
             return response.json()
 
-        return self._cached(("category", str(category_id), str(page)), fetch)
+        return self._cached(
+            (_KEY_CATEGORY, str(category_id), str(page)), fetch
+        )
 
     def get_events(self):
         """
@@ -184,7 +224,7 @@ class DiscourseAPI:
             return result
 
         try:
-            return self._cached(("events",), fetch)
+            return self._cached((_KEY_EVENTS,), fetch)
 
         except ValueError as e:
             raise ValueError(f"Failed to parse events response: {str(e)}")
@@ -208,6 +248,10 @@ class DiscourseAPI:
         :param limit: The maximum number of topics to return (default is 50,
         this is also the max).
         :param offset: The number of topics to skip (default is 0).
+
+        Note: upstream errors are converted to ValueError, except
+        RateLimitedError, which propagates when a cache is configured
+        so consumers can return a 503.
         """
 
         def fetch():
@@ -282,7 +326,7 @@ class DiscourseAPI:
             return [dict(zip(columns, row)) for row in rows]
 
         return self._cached(
-            ("topic_list", str(category_id), str(limit), str(offset)),
+            (_KEY_TOPIC_LIST, str(category_id), str(limit), str(offset)),
             fetch,
         )
 
@@ -294,6 +338,7 @@ class DiscourseAPI:
         - topic_id [int]: The topic ID
         """
         self._require_authentication()
+        self._breaker_guard()
 
         # See https://discourse.ubuntu.com/admin/plugins/explorer?id=122
         data_explorer_id = 122
@@ -308,7 +353,7 @@ class DiscourseAPI:
             headers=headers,
             data=params[0],
         )
-        response.raise_for_status()
+        self._raise_for_status_with_breaker(response)
         result = response.json()
 
         return result["rows"]
@@ -321,6 +366,7 @@ class DiscourseAPI:
         - category_id [int]: The category ID
         """
         self._require_authentication()
+        self._breaker_guard()
 
         # See https://discourse.ubuntu.com/admin/plugins/explorer?id=123
         data_explorer_id = 123
@@ -335,7 +381,7 @@ class DiscourseAPI:
             headers=headers,
             data=params[0],
         )
-        response.raise_for_status()
+        self._raise_for_status_with_breaker(response)
         result = response.json()
 
         return result["rows"]
@@ -358,7 +404,7 @@ class DiscourseAPI:
             if self.cache is not None:
                 # Drop the cached topic so the caller's re-parse sees
                 # the new content instead of latching stale cached data
-                self.cache.invalidate("topic", str(topic_id))
+                self.cache.invalidate(_KEY_TOPIC, str(topic_id))
             return True, most_recent_update
         else:
             return False, most_recent_update
@@ -384,7 +430,11 @@ class DiscourseAPI:
 
         if last_updated and most_recent_update > last_updated:
             if self.cache is not None:
-                self.cache.invalidate("category", str(category_id))
+                # Invalidate every fetch path the category consumers
+                # use, or they re-read stale cache and latch it
+                self.cache.invalidate(_KEY_CATEGORY, str(category_id))
+                self.cache.invalidate(_KEY_TOPIC_LIST, str(category_id))
+                self.cache.invalidate(_KEY_EVENTS)
             return True, most_recent_update
         else:
             return False, most_recent_update

--- a/canonicalwebteam/discourse/models.py
+++ b/canonicalwebteam/discourse/models.py
@@ -51,9 +51,14 @@ class DiscourseAPI:
         api_key=None,
         api_username=None,
         get_topics_query_id=None,
+        cache=None,
     ):
         """
         @param base_url: The Discourse URL (e.g. https://discourse.example.com)
+        @param cache: Optional ResponseCache. When set, responses are cached
+            per request signature, stale data is served while Discourse
+            errors, and an uncacheable HTTP 429 raises RateLimitedError
+            instead of HTTPError. When None (default) behaviour is unchanged.
         """
 
         self.base_url = base_url.rstrip("/")
@@ -61,6 +66,7 @@ class DiscourseAPI:
         self.get_topics_query_id = get_topics_query_id
         self.api_key = api_key
         self.api_username = api_username
+        self.cache = cache
 
         if api_key and api_username:
             self.session.headers = {
@@ -83,15 +89,26 @@ class DiscourseAPI:
     def __del__(self):
         self.session.close()
 
+    def _cached(self, key, fetch):
+        """
+        Route a fetch through the response cache when one is configured
+        """
+        if self.cache is None:
+            return fetch()
+        return self.cache.get(key, fetch)
+
     def get_topic(self, topic_id):
         """
         Retrieve topic object by path
         """
 
-        response = self.session.get(f"{self.base_url}/t/{topic_id}.json")
-        response.raise_for_status()
+        def fetch():
+            response = self.session.get(f"{self.base_url}/t/{topic_id}.json")
+            response.raise_for_status()
+            return response.json()
 
-        return response.json()
+        # str() so int and str topic ids share one cache entry
+        return self._cached(("topic", str(topic_id)), fetch)
 
     def get_topics(self, topic_ids):
         """
@@ -110,33 +127,38 @@ class DiscourseAPI:
         # Run query on Data Explorer with topic IDs
         topics = ",".join([str(i) for i in topic_ids])
 
-        response = self.session.post(
-            f"{self.base_url}/admin/plugins/explorer/"
-            f"queries/{self.get_topics_query_id}/run",
-            headers=headers,
-            data={"params": f'{{"topics":"{topics}"}}'},
-        )
-
-        result = response.json()
-
-        if "errors" in result and "rows" not in result:
-            raise DataExplorerError(
-                f'{result["errors"][0]} Have you set the right api_key?'
+        def fetch():
+            response = self.session.post(
+                f"{self.base_url}/admin/plugins/explorer/"
+                f"queries/{self.get_topics_query_id}/run",
+                headers=headers,
+                data={"params": f'{{"topics":"{topics}"}}'},
             )
 
-        pages = result["rows"]
-        return pages
+            result = response.json()
+
+            if "errors" in result and "rows" not in result:
+                raise DataExplorerError(
+                    f'{result["errors"][0]} Have you set the right api_key?'
+                )
+
+            return result["rows"]
+
+        return self._cached(("topics", topics), fetch)
 
     def get_topics_category(self, category_id, page=0):
         """
         Retrieves the full catergory object including metadata, groups, topics
         """
-        response = self.session.get(
-            f"{self.base_url}/c/{category_id}.json?page={page}"
-        )
-        response.raise_for_status()
 
-        return response.json()
+        def fetch():
+            response = self.session.get(
+                f"{self.base_url}/c/{category_id}.json?page={page}"
+            )
+            response.raise_for_status()
+            return response.json()
+
+        return self._cached(("category", str(category_id), str(page)), fetch)
 
     def get_events(self):
         """
@@ -147,7 +169,8 @@ class DiscourseAPI:
         Returns:
             dict: JSON response from the events endpoint containing all events
         """
-        try:
+
+        def fetch():
             response = self.session.get(
                 f"{self.base_url}/discourse-post-event/events.json"
                 f"?include_details=true&limit=100"
@@ -159,6 +182,9 @@ class DiscourseAPI:
                 raise ValueError("Unexpected response format from events API")
 
             return result
+
+        try:
+            return self._cached(("events",), fetch)
 
         except ValueError as e:
             raise ValueError(f"Failed to parse events response: {str(e)}")
@@ -183,7 +209,8 @@ class DiscourseAPI:
         this is also the max).
         :param offset: The number of topics to skip (default is 0).
         """
-        try:
+
+        def fetch():
             response = self.session.get(
                 f"{self.base_url}/search.json"
                 f"?q=tags:{tag}&limit={limit}&offset={offset}"
@@ -195,6 +222,12 @@ class DiscourseAPI:
                 raise ValueError("Unexpected response format from topics API")
 
             return result
+
+        try:
+            return self._cached(
+                ("topics_by_tag", str(tag), str(limit), str(offset)),
+                fetch,
+            )
 
         except ValueError as e:
             raise ValueError(f"Failed to parse topics response: {str(e)}")
@@ -231,20 +264,27 @@ class DiscourseAPI:
                 )
             },
         )
-        response = self.session.post(
-            f"{self.base_url}/admin/plugins/explorer/"
-            f"queries/{data_explorer_id}/run",
-            headers=headers,
-            data=params[0],
+
+        def fetch():
+            response = self.session.post(
+                f"{self.base_url}/admin/plugins/explorer/"
+                f"queries/{data_explorer_id}/run",
+                headers=headers,
+                data=params[0],
+            )
+
+            response.raise_for_status()
+            result = response.json()
+
+            columns = result.get("columns", [])
+            rows = result.get("rows", [])
+
+            return [dict(zip(columns, row)) for row in rows]
+
+        return self._cached(
+            ("topic_list", str(category_id), str(limit), str(offset)),
+            fetch,
         )
-
-        response.raise_for_status()
-        result = response.json()
-
-        columns = result.get("columns", [])
-        rows = result.get("rows", [])
-
-        return [dict(zip(columns, row)) for row in rows]
 
     def get_topics_last_activity_time(self, topic_id):
         """
@@ -315,6 +355,10 @@ class DiscourseAPI:
         most_recent_update = self.get_topics_last_activity_time(topic_id)[0][1]
 
         if last_updated and most_recent_update > last_updated:
+            if self.cache is not None:
+                # Drop the cached topic so the caller's re-parse sees
+                # the new content instead of latching stale cached data
+                self.cache.invalidate("topic", str(topic_id))
             return True, most_recent_update
         else:
             return False, most_recent_update
@@ -339,6 +383,8 @@ class DiscourseAPI:
         )[0][1]
 
         if last_updated and most_recent_update > last_updated:
+            if self.cache is not None:
+                self.cache.invalidate("category", str(category_id))
             return True, most_recent_update
         else:
             return False, most_recent_update
@@ -432,21 +478,26 @@ class DiscourseAPI:
 
         params = ({"params": json.dumps(params_dict)},)
 
-        response = self.session.post(
-            f"{self.base_url}/admin/plugins/explorer/"
-            f"queries/{data_explorer_id}/run",
-            headers=headers,
-            data=params[0],
+        def fetch():
+            response = self.session.post(
+                f"{self.base_url}/admin/plugins/explorer/"
+                f"queries/{data_explorer_id}/run",
+                headers=headers,
+                data=params[0],
+            )
+
+            response.raise_for_status()
+            result = response.json()
+
+            if not result["success"]:
+                raise DataExplorerError(result["errors"][0])
+
+            return result["rows"]
+
+        return self._cached(
+            ("engage_by_param", json.dumps(params_dict, sort_keys=True)),
+            fetch,
         )
-
-        response.raise_for_status()
-        result = response.json()
-
-        if not result["success"]:
-            raise DataExplorerError(result["errors"][0])
-
-        pages = result["rows"]
-        return pages
 
     def get_engage_pages_by_tag(self, category_id, tag, limit=50, offset=0):
         """
@@ -489,18 +540,23 @@ class DiscourseAPI:
 
         params = ({"params": json.dumps(params_dict)},)
 
-        response = self.session.post(
-            f"{self.base_url}/admin/plugins/explorer/"
-            f"queries/{data_explorer_id}/run",
-            headers=headers,
-            data=params[0],
+        def fetch():
+            response = self.session.post(
+                f"{self.base_url}/admin/plugins/explorer/"
+                f"queries/{data_explorer_id}/run",
+                headers=headers,
+                data=params[0],
+            )
+
+            response.raise_for_status()
+            result = response.json()
+
+            if not result["success"]:
+                raise DataExplorerError(result["errors"][0])
+
+            return result["rows"]
+
+        return self._cached(
+            ("engage_by_tag", json.dumps(params_dict, sort_keys=True)),
+            fetch,
         )
-
-        response.raise_for_status()
-        result = response.json()
-
-        if not result["success"]:
-            raise DataExplorerError(result["errors"][0])
-
-        pages = result["rows"]
-        return pages

--- a/canonicalwebteam/discourse/models.py
+++ b/canonicalwebteam/discourse/models.py
@@ -170,6 +170,13 @@ class DiscourseAPI:
                 data={"params": f'{{"topics":"{topics}"}}'},
             )
 
+            # A 429 body also carries an "errors" key; raise it as a
+            # rate limit instead of a Data Explorer query error. Other
+            # statuses fall through so query errors keep raising the
+            # descriptive DataExplorerError below.
+            if response.status_code == 429:
+                response.raise_for_status()
+
             result = response.json()
 
             if "errors" in result and "rows" not in result:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse",
-    version="7.5.0",
+    version="7.6.0",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical/canonicalwebteam.discourse",

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -242,3 +242,76 @@ class TestDiscourseAPICache(unittest.TestCase):
 
         with self.assertRaises(RateLimitedError):
             api.get_topic(5)
+
+
+class TestCircuitBreaker(unittest.TestCase):
+    """
+    One ResponseCache maps to one DiscourseAPI instance (one API key,
+    one quota): a 429 anywhere opens a cooldown for every key.
+    """
+
+    def setUp(self):
+        self.cache = ResponseCache(ttl=300)
+
+    def _trip_breaker(self, retry_after=None):
+        def rate_limited():
+            raise _http_error(429, retry_after=retry_after)
+
+        with self.assertRaises(RateLimitedError):
+            self.cache.get(("topic", "tripwire"), rate_limited)
+
+    def test_429_opens_breaker_for_other_keys(self):
+        self._trip_breaker()
+        calls = []
+
+        def fetch():
+            calls.append(1)
+            return "value"
+
+        with self.assertRaises(RateLimitedError):
+            self.cache.get(("topic", "other"), fetch)
+        self.assertEqual(calls, [])
+
+    def test_open_breaker_serves_stale_without_fetching(self):
+        key = ("topic", "1")
+        self.cache.get(key, lambda: "stale")
+        _expire(self.cache, key)
+        self._trip_breaker()
+
+        calls = []
+
+        def fetch():
+            calls.append(1)
+            return "fresh"
+
+        self.assertEqual(self.cache.get(key, fetch), "stale")
+        self.assertEqual(calls, [])
+
+    def test_breaker_respects_retry_after_header(self):
+        self._trip_breaker(retry_after=300)
+
+        with self.assertRaises(RateLimitedError) as context:
+            self.cache.get(("topic", "other"), lambda: "x")
+        self.assertGreater(context.exception.retry_after, 200)
+        self.assertLessEqual(context.exception.retry_after, 300)
+
+    def test_breaker_closes_after_cooldown(self):
+        self._trip_breaker()
+        # Force the cooldown into the past
+        self.cache._cooldown_until = 0.0
+
+        self.assertEqual(self.cache.get(("topic", "1"), lambda: "v"), "v")
+
+    def test_429_with_stale_still_opens_breaker(self):
+        key = ("topic", "1")
+        self.cache.get(key, lambda: "stale")
+        _expire(self.cache, key)
+
+        def rate_limited():
+            raise _http_error(429)
+
+        # Stale is served for this key...
+        self.assertEqual(self.cache.get(key, rate_limited), "stale")
+        # ...but the breaker still opens for everything else
+        with self.assertRaises(RateLimitedError):
+            self.cache.get(("topic", "other"), lambda: "x")

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -244,6 +244,23 @@ class TestDiscourseAPICache(unittest.TestCase):
         with self.assertRaises(RateLimitedError):
             api.get_topic(5)
 
+    def test_rate_limited_get_topics_opens_breaker(self):
+        # Discourse 429s carry an errors key, which must not be
+        # mistaken for a Data Explorer query error
+        api, session = self._make_api(cache=ResponseCache(ttl=300))
+        response = requests.Response()
+        response.status_code = 429
+        response._content = (
+            b'{"errors": ["Rate limit exceeded"],'
+            b' "error_type": "rate_limit"}'
+        )
+        session.post.return_value = response
+
+        with self.assertRaises(RateLimitedError):
+            api.get_topics([1, 2])
+
+        self.assertGreater(api.cache.cooldown_remaining(), 0)
+
 
 class TestCircuitBreaker(unittest.TestCase):
     """

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,4 +1,5 @@
 # Standard library
+import time
 import unittest
 from unittest.mock import Mock
 
@@ -315,3 +316,179 @@ class TestCircuitBreaker(unittest.TestCase):
         # ...but the breaker still opens for everything else
         with self.assertRaises(RateLimitedError):
             self.cache.get(("topic", "other"), lambda: "x")
+
+
+class TestRevocation(unittest.TestCase):
+    """
+    Deleted or de-listed content (403/404/410) must stop being served,
+    not live on via the stale-on-error path.
+    """
+
+    def setUp(self):
+        self.cache = ResponseCache(ttl=300)
+
+    def test_revocation_statuses_drop_stale_entry_and_raise(self):
+        for status in (403, 404, 410):
+            with self.subTest(status=status):
+                cache = ResponseCache(ttl=300)
+                key = ("topic", "1")
+                cache.get(key, lambda: "revoked-content")
+                _expire(cache, key)
+
+                def gone():
+                    raise _http_error(status)
+
+                with self.assertRaises(HTTPError):
+                    cache.get(key, gone)
+                self.assertNotIn(key, cache._entries)
+
+    def test_server_errors_still_serve_stale(self):
+        key = ("topic", "1")
+        self.cache.get(key, lambda: "stale")
+        _expire(self.cache, key)
+
+        def failing():
+            raise _http_error(502)
+
+        self.assertEqual(self.cache.get(key, failing), "stale")
+
+
+class TestCategoryUpdateInvalidation(unittest.TestCase):
+    def test_category_update_invalidates_topic_list_and_events(self):
+        session = Mock()
+        api = DiscourseAPI(
+            base_url="https://discourse.example.com",
+            session=session,
+            api_key="key",
+            api_username="user",
+            cache=ResponseCache(ttl=300),
+        )
+
+        session.post.return_value = _response(
+            {"columns": ["id"], "rows": [[1]]}
+        )
+        session.get.return_value = _response({"events": []})
+
+        api.get_topic_list_by_category(5)
+        api.get_events()
+        self.assertEqual(session.post.call_count, 1)
+        self.assertEqual(session.get.call_count, 1)
+
+        # Activity query reports an update newer than last_updated
+        session.post.return_value = _response({"rows": [[5, "2026-07-06"]]})
+        updated, _ = api.check_for_category_updates(5, "2026-07-01")
+        self.assertTrue(updated)
+        self.assertEqual(session.post.call_count, 2)
+
+        # Both consumers of the update check must refetch, not serve
+        # the cached pre-update data
+        session.post.return_value = _response(
+            {"columns": ["id"], "rows": [[2]]}
+        )
+        api.get_topic_list_by_category(5)
+        api.get_events()
+        self.assertEqual(session.post.call_count, 3)
+        self.assertEqual(session.get.call_count, 2)
+
+
+class TestBreakerGuardsProbes(unittest.TestCase):
+    def _make_api(self, cache):
+        session = Mock()
+        api = DiscourseAPI(
+            base_url="https://discourse.example.com",
+            session=session,
+            api_key="key",
+            api_username="user",
+            cache=cache,
+        )
+        return api, session
+
+    def test_probe_short_circuits_during_cooldown(self):
+        cache = ResponseCache(ttl=300)
+        api, session = self._make_api(cache)
+        cache._cooldown_until = time.monotonic() + 120
+
+        with self.assertRaises(RateLimitedError) as context:
+            api.get_topics_last_activity_time(1)
+
+        session.post.assert_not_called()
+        self.assertGreater(context.exception.retry_after, 60)
+
+    def test_probe_429_opens_breaker(self):
+        cache = ResponseCache(ttl=300)
+        api, session = self._make_api(cache)
+        response = requests.Response()
+        response.status_code = 429
+        session.post.return_value = response
+
+        with self.assertRaises(RateLimitedError):
+            api.get_categories_last_activity_time(5)
+
+        # The breaker is now open: cached fetches short-circuit
+        with self.assertRaises(RateLimitedError):
+            cache.get(("topic", "other"), lambda: "x")
+
+    def test_probe_without_cache_keeps_raising_http_error(self):
+        api, session = self._make_api(cache=None)
+        response = requests.Response()
+        response.status_code = 429
+        session.post.return_value = response
+
+        with self.assertRaises(HTTPError):
+            api.get_topics_last_activity_time(1)
+
+
+class TestEdgeBehaviours(unittest.TestCase):
+    def test_first_429_retry_after_matches_breaker_minimum(self):
+        cache = ResponseCache(ttl=300)
+
+        def rate_limited():
+            raise _http_error(429, retry_after=5)
+
+        with self.assertRaises(RateLimitedError) as context:
+            cache.get(("topic", "1"), rate_limited)
+        self.assertGreaterEqual(context.exception.retry_after, 60)
+
+    def test_max_size_one_still_evicts(self):
+        cache = ResponseCache(ttl=300, max_size=1)
+        cache.get(("topic", "1"), lambda: "one")
+        cache.get(("topic", "2"), lambda: "two")
+
+        self.assertEqual(len(cache._entries), 1)
+        self.assertIn(("topic", "2"), cache._entries)
+
+    def test_get_topics_key_is_order_insensitive(self):
+        session = Mock()
+        api = DiscourseAPI(
+            base_url="https://discourse.example.com",
+            session=session,
+            api_key="key",
+            api_username="user",
+            cache=ResponseCache(ttl=300),
+        )
+        session.post.return_value = _response({"rows": [["cooked"]]})
+
+        api.get_topics([1, 2])
+        api.get_topics([2, 1])
+
+        session.post.assert_called_once()
+
+
+class TestViewRateLimitHandling(unittest.TestCase):
+    """
+    The package's own view classes must translate RateLimitedError into
+    a 503, not let it escape as an unhandled exception (500).
+    """
+
+    def test_category_topic_by_id_translates_to_503(self):
+        from werkzeug.exceptions import ServiceUnavailable
+
+        from canonicalwebteam.discourse.app import Category
+
+        parser = Mock()
+        parser.api.get_topic.side_effect = RateLimitedError(retry_after=42)
+        category = Category(parser, category_id=5)
+
+        with self.assertRaises(ServiceUnavailable) as context:
+            category.get_topic_by_id(9)
+        self.assertEqual(context.exception.retry_after, 42)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,244 @@
+# Standard library
+import unittest
+from unittest.mock import Mock
+
+# Packages
+import requests
+from requests.exceptions import ConnectionError as RequestsConnectionError
+from requests.exceptions import HTTPError
+
+# Local
+from canonicalwebteam.discourse.cache import ResponseCache
+from canonicalwebteam.discourse.exceptions import RateLimitedError
+from canonicalwebteam.discourse.models import DiscourseAPI
+
+
+def _http_error(status_code, retry_after=None):
+    response = requests.Response()
+    response.status_code = status_code
+    if retry_after is not None:
+        response.headers["Retry-After"] = str(retry_after)
+    return HTTPError(response=response)
+
+
+def _expire(cache, key, seconds=3600):
+    """Age a cache entry so the next read attempts a refresh"""
+    timestamp, value = cache._entries[key]
+    cache._entries[key] = (timestamp - seconds, value)
+
+
+class TestResponseCache(unittest.TestCase):
+    def setUp(self):
+        self.cache = ResponseCache(ttl=300)
+
+    def test_fresh_value_served_from_cache(self):
+        calls = []
+
+        def fetch():
+            calls.append(1)
+            return "value"
+
+        self.assertEqual(self.cache.get(("topic", "1"), fetch), "value")
+        self.assertEqual(self.cache.get(("topic", "1"), fetch), "value")
+        self.assertEqual(len(calls), 1)
+
+    def test_expired_value_is_refetched(self):
+        values = iter(["first", "second"])
+        key = ("topic", "1")
+
+        self.cache.get(key, lambda: next(values))
+        _expire(self.cache, key)
+        self.assertEqual(self.cache.get(key, lambda: next(values)), "second")
+
+    def test_empty_results_expire_faster(self):
+        cache = ResponseCache(ttl=300, negative_ttl=60)
+        key = ("engage", "/missing")
+        values = iter([[], ["found"]])
+
+        cache.get(key, lambda: next(values))
+        # Age the entry past negative_ttl but not past ttl
+        _expire(cache, key, seconds=90)
+        self.assertEqual(cache.get(key, lambda: next(values)), ["found"])
+
+    def test_serves_stale_on_http_error(self):
+        key = ("topic", "1")
+        self.cache.get(key, lambda: "stale")
+        _expire(self.cache, key)
+
+        def failing():
+            raise _http_error(500)
+
+        self.assertEqual(self.cache.get(key, failing), "stale")
+
+    def test_serves_stale_on_connection_error(self):
+        key = ("topic", "1")
+        self.cache.get(key, lambda: "stale")
+        _expire(self.cache, key)
+
+        def failing():
+            raise RequestsConnectionError("connection refused")
+
+        self.assertEqual(self.cache.get(key, failing), "stale")
+
+    def test_stale_serve_backs_off_refetching(self):
+        key = ("topic", "1")
+        self.cache.get(key, lambda: "stale")
+        _expire(self.cache, key)
+
+        calls = []
+
+        def failing():
+            calls.append(1)
+            raise _http_error(500)
+
+        self.assertEqual(self.cache.get(key, failing), "stale")
+        # Entry was re-stamped: the immediate retry must not fetch again
+        self.assertEqual(self.cache.get(key, failing), "stale")
+        self.assertEqual(len(calls), 1)
+
+    def test_rate_limit_without_cache_raises_typed_error(self):
+        def rate_limited():
+            raise _http_error(429, retry_after=300)
+
+        with self.assertRaises(RateLimitedError) as context:
+            self.cache.get(("topic", "1"), rate_limited)
+        self.assertEqual(context.exception.retry_after, 300)
+
+    def test_rate_limit_retry_after_is_clamped(self):
+        def rate_limited():
+            raise _http_error(429, retry_after=99999)
+
+        with self.assertRaises(RateLimitedError) as context:
+            self.cache.get(("topic", "1"), rate_limited)
+        self.assertLessEqual(context.exception.retry_after, 600)
+
+    def test_rate_limit_with_cache_serves_stale(self):
+        key = ("topic", "1")
+        self.cache.get(key, lambda: "stale")
+        _expire(self.cache, key)
+
+        def rate_limited():
+            raise _http_error(429)
+
+        self.assertEqual(self.cache.get(key, rate_limited), "stale")
+
+    def test_other_http_errors_without_cache_are_raised(self):
+        def failing():
+            raise _http_error(404)
+
+        with self.assertRaises(HTTPError):
+            self.cache.get(("topic", "1"), failing)
+
+    def test_eviction_drops_expired_then_oldest(self):
+        cache = ResponseCache(ttl=300, max_size=4)
+        for index in range(4):
+            cache.get(("topic", str(index)), lambda i=index: i)
+
+        # All fresh and full: inserting a new key drops the oldest half
+        cache.get(("topic", "new"), lambda: "new")
+
+        self.assertNotIn(("topic", "0"), cache._entries)
+        self.assertIn(("topic", "3"), cache._entries)
+        self.assertIn(("topic", "new"), cache._entries)
+        self.assertLess(len(cache._entries), 5)
+
+    def test_invalidate_exact_key(self):
+        values = iter(["first", "second"])
+        key = ("topic", "1")
+
+        self.cache.get(key, lambda: next(values))
+        self.cache.invalidate("topic", "1")
+        self.assertEqual(self.cache.get(key, lambda: next(values)), "second")
+
+    def test_invalidate_by_prefix(self):
+        self.cache.get(("category", "5", "0"), lambda: "page0")
+        self.cache.get(("category", "5", "1"), lambda: "page1")
+        self.cache.get(("topic", "9"), lambda: "topic")
+
+        self.cache.invalidate("category", "5")
+
+        self.assertNotIn(("category", "5", "0"), self.cache._entries)
+        self.assertNotIn(("category", "5", "1"), self.cache._entries)
+        self.assertIn(("topic", "9"), self.cache._entries)
+
+
+def _response(json_data, status_code=200):
+    response = Mock()
+    response.status_code = status_code
+    response.json.return_value = json_data
+    response.raise_for_status.return_value = None
+    return response
+
+
+class TestDiscourseAPICache(unittest.TestCase):
+    def _make_api(self, cache=None):
+        session = Mock()
+        api = DiscourseAPI(
+            base_url="https://discourse.example.com",
+            session=session,
+            api_key="key",
+            api_username="user",
+            cache=cache,
+        )
+        return api, session
+
+    def test_without_cache_every_call_fetches(self):
+        api, session = self._make_api()
+        session.get.return_value = _response({"id": 5})
+
+        api.get_topic(5)
+        api.get_topic(5)
+
+        self.assertEqual(session.get.call_count, 2)
+
+    def test_get_topic_is_cached(self):
+        api, session = self._make_api(cache=ResponseCache(ttl=300))
+        session.get.return_value = _response({"id": 5})
+
+        self.assertEqual(api.get_topic(5), {"id": 5})
+        self.assertEqual(api.get_topic(5), {"id": 5})
+        session.get.assert_called_once()
+
+    def test_get_topic_int_and_str_ids_share_one_entry(self):
+        api, session = self._make_api(cache=ResponseCache(ttl=300))
+        session.get.return_value = _response({"id": 5})
+
+        api.get_topic(5)
+        api.get_topic("5")
+
+        session.get.assert_called_once()
+
+    def test_engage_pages_cached_per_params(self):
+        api, session = self._make_api(cache=ResponseCache(ttl=300))
+        session.post.return_value = _response(
+            {"success": True, "rows": [["row"]]}
+        )
+
+        api.get_engage_pages_by_param(category_id=51, key="path", value="/x")
+        api.get_engage_pages_by_param(category_id=51, key="path", value="/x")
+        api.get_engage_pages_by_param(category_id=51, key="path", value="/y")
+
+        self.assertEqual(session.post.call_count, 2)
+
+    def test_topic_update_invalidates_cached_topic(self):
+        api, session = self._make_api(cache=ResponseCache(ttl=300))
+        session.get.return_value = _response({"id": 5, "title": "old"})
+
+        api.get_topic(5)
+
+        # The activity-time query reports an update newer than last_updated
+        session.post.return_value = _response({"rows": [[5, "2026-07-03"]]})
+        updated, _ = api.check_for_topic_updates(5, "2026-07-01")
+        self.assertTrue(updated)
+
+        session.get.return_value = _response({"id": 5, "title": "new"})
+        self.assertEqual(api.get_topic(5)["title"], "new")
+
+    def test_rate_limited_topic_raises_typed_error(self):
+        api, session = self._make_api(cache=ResponseCache(ttl=300))
+        response = requests.Response()
+        response.status_code = 429
+        session.get.return_value = response
+
+        with self.assertRaises(RateLimitedError):
+            api.get_topic(5)


### PR DESCRIPTION
## Done

- Add optional `cache` parameter to `DiscourseAPI`: pass a `ResponseCache` to cache responses per request signature.
- Add a per-instance circuit breaker: a 429 opens a cooldown (honouring `Retry-After`) for every key on that instance — one cache maps to one API key, i.e., one rate-limit quota.
- Raise a typed `RateLimitedError` (carries `retry_after`) instead of a bare `HTTPError` when Discourse returns 429 and nothing is cached, so consumers can return a 503 instead of a 500.
- Invalidate cached topics/categories when `check_for_topic_updates`/`check_for_category_updates` detect a change, so edits appear immediately.
- Fully backward compatible: behaviour is unchanged when `cache` is not passed.


Context: crawler traffic exhausting the shared Discourse API rate limit caused the ubuntu.com Discourse-backed pages (engage, community, docs) to 500 (fixed site-side in canonical/ubuntu.com#16538 / #16542). This moves the mechanism into the package so every consumer site gets it from a version bump instead of per-view wrapping.

## QA

- `tox` — 103 tests passing (24 new in `tests/test_cache.py`), `tox -e lint` clean.
- README has a usage example (`ResponseCache` construction + `RateLimitedError` handler).

## Fixes
https://warthogs.atlassian.net/browse/WD-37683