### PR TITLE
fix: return a list from get_topics_in_category error fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 7.6.1 [07-07-2026]
+**Fixed** Category.get_topics_in_category error fallback
+- Return an empty list instead of an empty dict when the first fetch fails, matching the success path's return type (callers slice and iterate the result)
+
 ### 7.6.0 [04-07-2026]
 **Added** DiscourseAPI response caching and rate-limit handling
 - New optional `cache` parameter on `DiscourseAPI`: pass a `ResponseCache` to cache responses per request signature, serve stale data while Discourse errors, and bound retries during outages

--- a/canonicalwebteam/discourse/app.py
+++ b/canonicalwebteam/discourse/app.py
@@ -870,7 +870,8 @@ class Category:
 
         except Exception:
             if self.category_topics is None:
-                return {}
+                # Callers slice and iterate this like the success path
+                return []
 
         return self.category_topics
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse",
-    version="7.6.0",
+    version="7.6.1",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical/canonicalwebteam.discourse",

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -509,3 +509,16 @@ class TestViewRateLimitHandling(unittest.TestCase):
         with self.assertRaises(ServiceUnavailable) as context:
             category.get_topic_by_id(9)
         self.assertEqual(context.exception.retry_after, 42)
+
+    def test_get_topics_in_category_error_fallback_is_a_list(self):
+        from canonicalwebteam.discourse.app import Category
+
+        parser = Mock()
+        parser.api.check_for_category_updates.side_effect = RateLimitedError(
+            retry_after=42
+        )
+        category = Category(parser, category_id=5)
+
+        # Views slice and iterate this; the error fallback must be a
+        # list like the success path, not a dict
+        self.assertEqual(category.get_topics_in_category(), [])


### PR DESCRIPTION
## Done

- `Category.get_topics_in_category` returned `{}` (a dict) from its error fallback when the first fetch fails, while the success path returns a list. Callers that slice or iterate the result crash with `TypeError: unhashable type: 'slice'` (seen on ubuntu.com `/community` during a Discourse rate-limit). It now returns `[]`.
- Bump version to 7.6.1.

## QA

- `pytest` — 115 passing (1 new test covering the fallback type)