### PR TITLE
feat: add optional anonymous reads to DiscourseAPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 7.7.0 [08-07-2026]
+**Added** optional anonymous reads
+- New `authenticated_reads` parameter on `DiscourseAPI` (default `True`, behaviour unchanged): when `False`, public GET endpoints are requested without credentials so they stop counting against the shared admin API quota and become proxy-cacheable; Data Explorer queries always stay authenticated
+- Only enable it after verifying the fetched content is visible to anonymous users
+
 ### 7.6.1 [07-07-2026]
 **Fixed** Category.get_topics_in_category error fallback
 - Return an empty list instead of an empty dict when the first fetch fails, matching the success path's return type (callers slice and iterate the result)

--- a/README.md
+++ b/README.md
@@ -37,6 +37,36 @@ discourse.init_app(app)
 
 Once this is added you will need to add the file `document.html` to your template folder.
 
+## Anonymous reads (optional)
+
+By default every request carries the API credentials, so it counts against
+Discourse's *admin API* quota — a single bucket shared by **all** API keys
+on the instance (`max_admin_api_reqs_per_minute`, 60/min by default).
+Public GET endpoints (`/t/<id>.json`, `/c/<id>.json`, `/search.json`,
+events) don't need credentials when the content is publicly visible, and
+anonymous requests don't draw from that quota (and can be served by
+caching proxies in front of Discourse).
+
+Pass `authenticated_reads=False` to request public endpoints anonymously;
+Data Explorer queries always keep the credentials, as that endpoint is
+admin-only:
+
+```python
+api = DiscourseAPI(
+    base_url="https://discourse.example.com/",
+    session=session,
+    api_key=DISCOURSE_API_KEY,
+    api_username=DISCOURSE_API_USERNAME,
+    authenticated_reads=False,
+)
+```
+
+**Verify your content is publicly visible first**: Discourse returns 404
+for topics and categories that anonymous users cannot see, so flipping
+this on for content in login-required categories breaks those pages.
+Check every topic/category id your site fetches with an unauthenticated
+`curl` (or a logged-out browser) before opting in.
+
 ## Response caching and rate-limit handling (optional)
 
 Discourse rate-limits API credentials (HTTP 429). Sites that fetch content

--- a/canonicalwebteam/discourse/models.py
+++ b/canonicalwebteam/discourse/models.py
@@ -61,6 +61,7 @@ class DiscourseAPI:
         api_username=None,
         get_topics_query_id=None,
         cache=None,
+        authenticated_reads=True,
     ):
         """
         @param base_url: The Discourse URL (e.g. https://discourse.example.com)
@@ -68,6 +69,12 @@ class DiscourseAPI:
             per request signature, stale data is served while Discourse
             errors, and an uncacheable HTTP 429 raises RateLimitedError
             instead of HTTPError. When None (default) behaviour is unchanged.
+        @param authenticated_reads: When True (default) credentials are
+            attached to the session, so every request is authenticated
+            and counts against the shared admin API quota. When False,
+            public GET endpoints are requested anonymously (verify the
+            content is publicly visible first!) and only Data Explorer
+            requests carry credentials.
         """
 
         self.base_url = base_url.rstrip("/")
@@ -77,11 +84,14 @@ class DiscourseAPI:
         self.api_username = api_username
         self.cache = cache
 
+        self._auth_headers = {}
         if api_key and api_username:
-            self.session.headers = {
+            self._auth_headers = {
                 "Api-Key": api_key,
                 "Api-Username": api_username,
             }
+            if authenticated_reads:
+                self.session.headers = dict(self._auth_headers)
 
     def _require_authentication(self):
         """
@@ -157,6 +167,7 @@ class DiscourseAPI:
         headers = {
             "Accept": "application/json",
             "Content-Type": "multipart/form-data;",
+            **self._auth_headers,
         }
 
         # Run query on Data Explorer with topic IDs
@@ -306,6 +317,7 @@ class DiscourseAPI:
         headers = {
             "Accept": "application/json",
             "Content-Type": "multipart/form-data;",
+            **self._auth_headers,
         }
         params = (
             {
@@ -352,6 +364,7 @@ class DiscourseAPI:
         headers = {
             "Accept": "application/json",
             "Content-Type": "multipart/form-data;",
+            **self._auth_headers,
         }
         params = ({"params": (f'{{"topic_id":"{topic_id}"}} ')},)
         response = self.session.post(
@@ -380,6 +393,7 @@ class DiscourseAPI:
         headers = {
             "Accept": "application/json",
             "Content-Type": "multipart/form-data;",
+            **self._auth_headers,
         }
         params = ({"params": (f'{{"category_id":"{category_id}"}} ')},)
         response = self.session.post(
@@ -502,6 +516,7 @@ class DiscourseAPI:
         headers = {
             "Accept": "application/json",
             "Content-Type": "multipart/form-data;",
+            **self._auth_headers,
         }
         # See https://discourse.ubuntu.com/admin/plugins/explorer?id=16
         data_explorer_id = 16
@@ -578,6 +593,7 @@ class DiscourseAPI:
         headers = {
             "Accept": "application/json",
             "Content-Type": "multipart/form-data;",
+            **self._auth_headers,
         }
         # See https://discourse.ubuntu.com/admin/plugins/explorer?id=55
         data_explorer_id = 55

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse",
-    version="7.6.1",
+    version="7.7.0",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical/canonicalwebteam.discourse",

--- a/tests/test_auth_scope.py
+++ b/tests/test_auth_scope.py
@@ -1,0 +1,129 @@
+# Standard library
+import unittest
+from unittest.mock import Mock
+
+# Packages
+import requests
+
+# Local
+from canonicalwebteam.discourse.models import DiscourseAPI
+
+
+def _response(json_data, status_code=200):
+    response = Mock()
+    response.status_code = status_code
+    response.json.return_value = json_data
+    response.raise_for_status.return_value = None
+    return response
+
+
+def _make_api(session, authenticated_reads=True):
+    return DiscourseAPI(
+        base_url="https://discourse.example.com",
+        session=session,
+        api_key="key",
+        api_username="user",
+        authenticated_reads=authenticated_reads,
+    )
+
+
+class TestAuthenticatedReadsDefault(unittest.TestCase):
+    """
+    Default behaviour is unchanged: credentials are attached to the
+    session, so every request is authenticated.
+    """
+
+    def test_default_sets_session_headers(self):
+        session = requests.Session()
+        _make_api(session)
+
+        self.assertEqual(session.headers.get("Api-Key"), "key")
+        self.assertEqual(session.headers.get("Api-Username"), "user")
+
+
+class TestAnonymousReads(unittest.TestCase):
+    """
+    With authenticated_reads=False, public GET endpoints are anonymous
+    (they don't count against the shared admin API quota and become
+    proxy-cacheable) while Data Explorer requests stay authenticated.
+    """
+
+    def test_session_headers_are_not_modified(self):
+        session = requests.Session()
+        _make_api(session, authenticated_reads=False)
+
+        self.assertNotIn("Api-Key", session.headers)
+        self.assertNotIn("Api-Username", session.headers)
+
+    def test_get_topic_sends_no_auth_headers(self):
+        session = Mock()
+        session.get.return_value = _response({"id": 5})
+        api = _make_api(session, authenticated_reads=False)
+
+        api.get_topic(5)
+
+        self.assertNotIn("headers", session.get.call_args.kwargs)
+
+    def test_get_topics_authenticates_the_data_explorer_call(self):
+        session = Mock()
+        session.post.return_value = _response({"rows": [["cooked"]]})
+        api = _make_api(session, authenticated_reads=False)
+
+        api.get_topics([1, 2])
+
+        headers = session.post.call_args.kwargs["headers"]
+        self.assertEqual(headers.get("Api-Key"), "key")
+        self.assertEqual(headers.get("Api-Username"), "user")
+
+    def test_topic_list_by_category_authenticates(self):
+        session = Mock()
+        session.post.return_value = _response(
+            {"columns": ["id"], "rows": [[1]]}
+        )
+        api = _make_api(session, authenticated_reads=False)
+
+        api.get_topic_list_by_category(5)
+
+        headers = session.post.call_args.kwargs["headers"]
+        self.assertEqual(headers.get("Api-Key"), "key")
+
+    def test_engage_pages_by_param_authenticates(self):
+        session = Mock()
+        session.post.return_value = _response(
+            {"success": True, "rows": [["row"]]}
+        )
+        api = _make_api(session, authenticated_reads=False)
+
+        api.get_engage_pages_by_param(category_id=51, key="path", value="/x")
+
+        headers = session.post.call_args.kwargs["headers"]
+        self.assertEqual(headers.get("Api-Key"), "key")
+
+    def test_engage_pages_by_tag_authenticates(self):
+        session = Mock()
+        session.post.return_value = _response(
+            {"success": True, "rows": [["row"]]}
+        )
+        api = _make_api(session, authenticated_reads=False)
+
+        api.get_engage_pages_by_tag(category_id=51, tag="events")
+
+        headers = session.post.call_args.kwargs["headers"]
+        self.assertEqual(headers.get("Api-Key"), "key")
+
+    def test_activity_probes_authenticate(self):
+        session = Mock()
+        session.post.return_value = _response({"rows": [[1, "2026-07-08"]]})
+        api = _make_api(session, authenticated_reads=False)
+
+        api.get_topics_last_activity_time(1)
+        headers = session.post.call_args.kwargs["headers"]
+        self.assertEqual(headers.get("Api-Key"), "key")
+
+        api.get_categories_last_activity_time(1)
+        headers = session.post.call_args.kwargs["headers"]
+        self.assertEqual(headers.get("Api-Key"), "key")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Done

- New `authenticated_reads` parameter on `DiscourseAPI` (default `True` — behaviour unchanged). When `False`:
  - Public GET endpoints (`get_topic`, `get_topics_category`, `get_events`, `get_topics_by_tag`) are requested **anonymously**
  - Data Explorer queries (all four content queries + both activity probes) always keep the `Api-Key`/`Api-Username` headers, since that endpoint is admin-only

## Why

Discourse counts **every** request carrying an `Api-Key` header against the admin API quota — one global bucket (`max_admin_api_reqs_per_minute`, default 60/min) shared by *all* keys on the instance. `DiscourseAPI` attaches the credentials to the session, so even plain topic reads that would work anonymously draw from that scarce bucket, and being authenticated also prevents fronting caches from serving them.

During the recent rate-limit incidents on discourse.ubuntu.com, this meant public topic/category/events reads competed with the Data Explorer queries that genuinely need authentication. We verified the ubuntu.com community content (topics 62344/40911/60, categories 129/419/11, `search.json`, events.json) is anonymously visible — with this flag, those reads leave the admin bucket entirely, leaving it for Data Explorer only.

Opt-in per instance because content visibility varies: sites must verify their topic/category IDs are public before enabling (documented in the README).

## QA

- `pytest` — 123 passing (8 new in `tests/test_auth_scope.py`); lint clean
- Default behaviour is byte-identical: credentials on the session, all requests authenticated