### PR TITLE
feat: log circuit breaker decisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+### 7.7.1 [09-07-2026]
+**Added** circuit breaker and stale-serve logging
+- The breaker and cache decisions now log (`canonicalwebteam.discourse` logger), so rate-limit incidents are visible in pod logs instead of silent 503s:
+  - WARNING when a 429 opens the breaker (with URL and cooldown length)
+  - WARNING when a request fails 503 because the breaker is open and no cached copy exists
+  - WARNING when an upstream error is absorbed by serving a stale copy
+  - INFO when the open breaker serves a cached copy, when an uncached freshness probe is skipped, and when the breaker closes
+- No behaviour change; logging only
+
 ### 7.7.0 [08-07-2026]
 **Added** optional anonymous reads
 - New `authenticated_reads` parameter on `DiscourseAPI` (default `True`, behaviour unchanged): when `False`, public GET endpoints are requested without credentials so they stop counting against the shared admin API quota and become proxy-cacheable; Data Explorer queries always stay authenticated

--- a/canonicalwebteam/discourse/cache.py
+++ b/canonicalwebteam/discourse/cache.py
@@ -17,6 +17,7 @@ minutes, regardless of traffic volume.
 """
 
 # Standard library
+import logging
 import threading
 import time
 
@@ -25,6 +26,8 @@ from requests.exceptions import RequestException
 
 # Local
 from canonicalwebteam.discourse.exceptions import RateLimitedError
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_RETRY_AFTER = 60
 MAX_RETRY_AFTER = 600
@@ -75,6 +78,11 @@ class ResponseCache:
     def _open_cooldown(self, response):
         delay = max(_retry_after_from(response), DEFAULT_RETRY_AFTER)
         self._cooldown_until = time.monotonic() + delay
+        logger.warning(
+            "Discourse returned 429 for %s: circuit breaker open for %ss",
+            getattr(response, "url", None) or "unknown URL",
+            delay,
+        )
 
     def _remaining_cooldown(self):
         return max(1, int(self._cooldown_until - time.monotonic()))
@@ -101,6 +109,12 @@ class ResponseCache:
         failing Discourse happens after ``error_retry`` seconds instead
         of on every request
         """
+        logger.warning(
+            "Discourse fetch failed: serving stale copy for %r, next "
+            "retry in %ss",
+            key,
+            self.error_retry,
+        )
         backoff_timestamp = (
             time.monotonic() - self._ttl_for(entry[1]) + self.error_retry
         )
@@ -145,9 +159,25 @@ class ResponseCache:
             return entry[1]
 
         if time.monotonic() < self._cooldown_until:
+            remaining = self._remaining_cooldown()
             if entry:
+                logger.info(
+                    "Discourse circuit breaker open (%ss left): "
+                    "serving cached copy for %r",
+                    remaining,
+                    key,
+                )
                 return entry[1]
-            raise RateLimitedError(retry_after=self._remaining_cooldown())
+            logger.warning(
+                "Discourse circuit breaker open (%ss left) and no "
+                "cached copy for %r: failing with Retry-After",
+                remaining,
+                key,
+            )
+            raise RateLimitedError(retry_after=remaining)
+        if self._cooldown_until:
+            self._cooldown_until = 0.0
+            logger.info("Discourse circuit breaker closed: resuming requests")
 
         try:
             value = fetch()

--- a/canonicalwebteam/discourse/cache.py
+++ b/canonicalwebteam/discourse/cache.py
@@ -168,7 +168,7 @@ class ResponseCache:
                     key,
                 )
                 return entry[1]
-            logger.warning(
+            logger.info(
                 "Discourse circuit breaker open (%ss left) and no "
                 "cached copy for %r: failing with Retry-After",
                 remaining,

--- a/canonicalwebteam/discourse/models.py
+++ b/canonicalwebteam/discourse/models.py
@@ -1,3 +1,4 @@
+import logging
 import re
 
 import requests
@@ -7,6 +8,8 @@ from canonicalwebteam.discourse.exceptions import (
     RateLimitedError,
 )
 import json
+
+logger = logging.getLogger(__name__)
 
 # Cache key prefixes, shared between the fetch sites and the
 # invalidation sites in check_for_topic_updates /
@@ -125,6 +128,11 @@ class DiscourseAPI:
         if self.cache is not None:
             remaining = self.cache.cooldown_remaining()
             if remaining:
+                logger.info(
+                    "Discourse circuit breaker open (%ss left): "
+                    "skipping uncached request",
+                    remaining,
+                )
                 raise RateLimitedError(retry_after=remaining)
 
     def _raise_for_status_with_breaker(self, response):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse",
-    version="7.7.0",
+    version="7.7.1",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical/canonicalwebteam.discourse",

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -553,7 +553,7 @@ class TestBreakerObservability(unittest.TestCase):
         cache = ResponseCache(ttl=300)
         cache._cooldown_until = time.monotonic() + 120
 
-        with self.assertLogs(self.LOGGER, level="WARNING") as logs:
+        with self.assertLogs(self.LOGGER, level="INFO") as logs:
             with self.assertRaises(RateLimitedError):
                 cache.get(("topic", "1"), lambda: "unreached")
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -522,3 +522,111 @@ class TestViewRateLimitHandling(unittest.TestCase):
         # Views slice and iterate this; the error fallback must be a
         # list like the success path, not a dict
         self.assertEqual(category.get_topics_in_category(), [])
+
+
+class TestBreakerObservability(unittest.TestCase):
+    """
+    Every breaker and stale-serve decision must leave a log line.
+    Silent 503s during a rate-limit incident look like an unexplained
+    outage from the pod logs (the breaker suppresses the very requests
+    that would have produced error tracebacks).
+    """
+
+    LOGGER = "canonicalwebteam.discourse"
+
+    def test_429_opening_breaker_is_logged(self):
+        cache = ResponseCache(ttl=300)
+
+        def fetch():
+            raise _http_error(429, retry_after=120)
+
+        with self.assertLogs(self.LOGGER, level="WARNING") as logs:
+            with self.assertRaises(RateLimitedError):
+                cache.get(("topic", "1"), fetch)
+
+        self.assertTrue(
+            any("circuit breaker open" in line for line in logs.output),
+            logs.output,
+        )
+
+    def test_short_circuit_without_stale_is_logged(self):
+        cache = ResponseCache(ttl=300)
+        cache._cooldown_until = time.monotonic() + 120
+
+        with self.assertLogs(self.LOGGER, level="WARNING") as logs:
+            with self.assertRaises(RateLimitedError):
+                cache.get(("topic", "1"), lambda: "unreached")
+
+        self.assertTrue(
+            any("no cached copy" in line for line in logs.output),
+            logs.output,
+        )
+
+    def test_short_circuit_with_stale_is_logged(self):
+        cache = ResponseCache(ttl=300)
+        key = ("topic", "1")
+        cache.get(key, lambda: "value")
+        _expire(cache, key)
+        cache._cooldown_until = time.monotonic() + 120
+
+        with self.assertLogs(self.LOGGER, level="INFO") as logs:
+            self.assertEqual(cache.get(key, lambda: "unreached"), "value")
+
+        self.assertTrue(
+            any("serving cached copy" in line for line in logs.output),
+            logs.output,
+        )
+
+    def test_stale_serve_on_upstream_error_is_logged(self):
+        cache = ResponseCache(ttl=300)
+        key = ("topic", "1")
+        cache.get(key, lambda: "value")
+        _expire(cache, key)
+
+        def fetch():
+            raise _http_error(500)
+
+        with self.assertLogs(self.LOGGER, level="WARNING") as logs:
+            self.assertEqual(cache.get(key, fetch), "value")
+
+        self.assertTrue(
+            any("serving stale" in line for line in logs.output),
+            logs.output,
+        )
+
+    def test_breaker_close_is_logged(self):
+        cache = ResponseCache(ttl=300)
+        # A cooldown that has just expired
+        cache._cooldown_until = time.monotonic() - 1
+
+        with self.assertLogs(self.LOGGER, level="INFO") as logs:
+            self.assertEqual(
+                cache.get(("topic", "1"), lambda: "value"), "value"
+            )
+
+        self.assertTrue(
+            any("circuit breaker closed" in line for line in logs.output),
+            logs.output,
+        )
+
+    def test_probe_short_circuit_is_logged(self):
+        cache = ResponseCache(ttl=300)
+        session = Mock()
+        api = DiscourseAPI(
+            base_url="https://discourse.example.com",
+            session=session,
+            api_key="key",
+            api_username="user",
+            cache=cache,
+        )
+        cache._cooldown_until = time.monotonic() + 120
+
+        with self.assertLogs(self.LOGGER, level="INFO") as logs:
+            with self.assertRaises(RateLimitedError):
+                api.get_topics_last_activity_time(1)
+
+        session.post.assert_not_called()
+        self.assertTrue(
+            any("skipping" in line.lower() for line in logs.output),
+            logs.output,
+        )


### PR DESCRIPTION
## Done

Adds logging to the circuit breaker and cache (7.7.1). During a rate-limit incident the breaker suppresses the failing requests, so pods emitted no logs while serving 503s — nobody could tell what was happening. 

Now every decision leaves a line on the `canonicalwebteam.discourse` logger:

- **WARNING**: a 429 opens the breaker (URL + cooldown length); a request 503s because the breaker is open with no cached copy; an upstream error is absorbed by serving stale
- **INFO**: the open breaker serves a cached copy; an uncached freshness probe is skipped; the breaker closes

Logging only — no behaviour change, no new dependencies (Sentry picks the WARNINGs up via its logging integration).

## QA
Check logs 
```
kubectl logs ubuntu-com-16574-demos-haus-5f95f64866-prhqb -f
```

and visit any discourse backed page like https://ubuntu-com-16574.demos.haus/community/uwn
<img width="1514" height="218" alt="image" src="https://github.com/user-attachments/assets/b5d2442a-1caf-47d0-9a81-5df2df91c6e6" />


- https://ubuntu-com-16574.demos.haus/engage

Used here https://github.com/canonical/ubuntu.com/pull/16574
