### PR TITLE
feat: add 10 retries limit for each discourse API request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+### 7.8.0 [10-07-2026]
+**Added** blocking retry on HTTP 429
+- Every `DiscourseAPI` request now blocks and retries when Discourse
+  responds 429, honouring its `Retry-After` header (60s fallback, capped
+  at 600s), for up to `max_rate_limit_retries` consecutive 429s (new
+  constructor param, default 600)
+- Once that safety cap is hit, the final 429 response is handled exactly
+  as before: a bare `HTTPError`, or the existing `cache`/circuit-breaker
+  behaviour (stale data / `RateLimitedError`) when a `cache` is configured
+- Applies underneath the response cache, at the HTTP request level, so it
+  takes effect whether or not `cache` is passed
+
 ### 7.7.1 [09-07-2026]
 **Added** circuit breaker and stale-serve logging
 - The breaker and cache decisions now log (`canonicalwebteam.discourse` logger), so rate-limit incidents are visible in pod logs instead of silent 503s:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - Every `DiscourseAPI` request now blocks and retries when Discourse
   responds 429, honouring its `Retry-After` header (60s fallback, capped
   at 600s), for up to `max_rate_limit_retries` consecutive 429s (new
-  constructor param, default 600)
+  constructor param, default 10)
 - Once that safety cap is hit, the final 429 response is handled exactly
   as before: a bare `HTTPError`, or the existing `cache`/circuit-breaker
   behaviour (stale data / `RateLimitedError`) when a `cache` is configured

--- a/README.md
+++ b/README.md
@@ -67,15 +67,44 @@ this on for content in login-required categories breaks those pages.
 Check every topic/category id your site fetches with an unauthenticated
 `curl` (or a logged-out browser) before opting in.
 
+## Rate-limit retries (default behaviour)
+
+Discourse rate-limits API credentials (HTTP 429). By default, every
+request blocks and retries when it hits a 429, honouring Discourse's
+`Retry-After` header (falling back to 60s, and capped at 600s, when the
+header is missing or absurdly large). It keeps retrying for as long as
+Discourse keeps saying 429, up to a safety cap of `max_rate_limit_retries`
+consecutive retries (default 600) so a persistently rate-limited
+credential can't hang a request forever. Past that cap, the request gives
+up and the final 429 response is handled exactly as before (a bare
+`HTTPError`, or the cache/circuit-breaker behaviour described below, when
+a `cache` is configured).
+
+```python
+api = DiscourseAPI(
+    base_url="https://forum.example.com/",
+    session=session,
+    max_rate_limit_retries=600,  # default; lower it to fail faster
+)
+```
+
+This blocks the calling thread for the retry duration, so in a
+request-handling process it ties up a worker for as long as the retries
+take. Lower `max_rate_limit_retries` (e.g. to 0 to disable retries and
+fail fast) for code paths where that's unacceptable, and/or pair it with
+a `ResponseCache` -- see below -- so most requests are served from cache
+and never reach Discourse in the first place.
+
 ## Response caching and rate-limit handling (optional)
 
-Discourse rate-limits API credentials (HTTP 429). Sites that fetch content
-from Discourse on every page render will exhaust that limit whenever
-crawlers cause bursts of traffic, turning every Discourse-backed page into
-a 500. Passing a `ResponseCache` to `DiscourseAPI` bounds how often each
-unique request reaches Discourse, serves the last known data while
-Discourse is erroring, and raises a typed `RateLimitedError` (instead of a
-bare `HTTPError`) when Discourse returns 429 and nothing is cached.
+Sites that fetch content from Discourse on every page render will exhaust
+the rate limit whenever crawlers cause bursts of traffic, turning every
+Discourse-backed page into a 500 (or, with the blocking retries above, a
+very slow response). Passing a `ResponseCache` to `DiscourseAPI` bounds
+how often each unique request reaches Discourse, serves the last known
+data while Discourse is erroring, and raises a typed `RateLimitedError`
+(instead of a bare `HTTPError`) once retries are exhausted on a 429 and
+nothing is cached.
 
 ```python
 from canonicalwebteam.discourse import DiscourseAPI, ResponseCache
@@ -121,8 +150,10 @@ Notes:
 - `check_for_topic_updates` and `check_for_category_updates` invalidate
   the corresponding cache entries when they detect an update, so edited
   content is re-fetched immediately rather than waiting out the TTL.
-- When `cache` is not passed, behaviour is exactly as before — the
-  feature is fully opt-in.
+- When `cache` is not passed, caching/circuit-breaker behaviour is exactly
+  as before — that feature is fully opt-in. The blocking retries above
+  still apply regardless, since they happen underneath, at the HTTP
+  request level.
 
 ## Local development
 

--- a/README.md
+++ b/README.md
@@ -72,19 +72,18 @@ Check every topic/category id your site fetches with an unauthenticated
 Discourse rate-limits API credentials (HTTP 429). By default, every
 request blocks and retries when it hits a 429, honouring Discourse's
 `Retry-After` header (falling back to 60s, and capped at 600s, when the
-header is missing or absurdly large). It keeps retrying for as long as
-Discourse keeps saying 429, up to a safety cap of `max_rate_limit_retries`
-consecutive retries (default 600) so a persistently rate-limited
-credential can't hang a request forever. Past that cap, the request gives
-up and the final 429 response is handled exactly as before (a bare
-`HTTPError`, or the cache/circuit-breaker behaviour described below, when
-a `cache` is configured).
+header is missing or absurdly large), up to a safety cap of
+`max_rate_limit_retries` consecutive retries (default 10) so a
+persistently rate-limited credential can't hang a request forever. Past
+that cap, the request gives up and the final 429 response is handled
+exactly as before (a bare `HTTPError`, or the cache/circuit-breaker
+behaviour described below, when a `cache` is configured).
 
 ```python
 api = DiscourseAPI(
     base_url="https://forum.example.com/",
     session=session,
-    max_rate_limit_retries=600,  # default; lower it to fail faster
+    max_rate_limit_retries=10,  # default; raise it to tolerate longer outages
 )
 ```
 

--- a/canonicalwebteam/discourse/models.py
+++ b/canonicalwebteam/discourse/models.py
@@ -1,5 +1,6 @@
 import logging
 import re
+import time
 
 import requests
 from canonicalwebteam.discourse.exceptions import (
@@ -18,6 +19,28 @@ _KEY_TOPIC = "topic"
 _KEY_CATEGORY = "category"
 _KEY_TOPIC_LIST = "topic_list"
 _KEY_EVENTS = "events"
+
+# Fallback/cap for the wait between retries of a 429, when honouring
+# Discourse's own Retry-After header (see _retry_after_seconds)
+DEFAULT_RETRY_AFTER = 60
+MAX_RETRY_AFTER = 600
+
+# Safety cap: give up blocking on a single request after this many
+# consecutive 429s, so a persistently rate-limited credential can't
+# hang a request forever. Overridable via DiscourseAPI(...).
+DEFAULT_MAX_RATE_LIMIT_RETRIES = 600
+
+
+def _retry_after_seconds(response):
+    """
+    Seconds to wait before retrying a 429, taken from Discourse's
+    Retry-After header. Falls back to DEFAULT_RETRY_AFTER when the
+    header is missing or invalid, and is capped at MAX_RETRY_AFTER.
+    """
+    value = response.headers.get("Retry-After", "").strip()
+    if value.isdecimal():
+        return min(int(value), MAX_RETRY_AFTER)
+    return DEFAULT_RETRY_AFTER
 
 
 def _normalise_tags(tags):
@@ -65,6 +88,7 @@ class DiscourseAPI:
         get_topics_query_id=None,
         cache=None,
         authenticated_reads=True,
+        max_rate_limit_retries=DEFAULT_MAX_RATE_LIMIT_RETRIES,
     ):
         """
         @param base_url: The Discourse URL (e.g. https://discourse.example.com)
@@ -78,6 +102,12 @@ class DiscourseAPI:
             public GET endpoints are requested anonymously (verify the
             content is publicly visible first!) and only Data Explorer
             requests carry credentials.
+        @param max_rate_limit_retries: Every request blocks and retries
+            on HTTP 429, honouring Discourse's Retry-After header, for up
+            to this many consecutive 429s before giving up and returning
+            the 429 response (default 600 -- effectively "keep retrying
+            for as long as we get 429s", with a safety cap so a request
+            can't hang forever).
         """
 
         self.base_url = base_url.rstrip("/")
@@ -86,6 +116,7 @@ class DiscourseAPI:
         self.api_key = api_key
         self.api_username = api_username
         self.cache = cache
+        self.max_rate_limit_retries = max_rate_limit_retries
 
         self._auth_headers = {}
         if api_key and api_username:
@@ -118,6 +149,40 @@ class DiscourseAPI:
         if self.cache is None:
             return fetch()
         return self.cache.get(key, fetch)
+
+    def _send_with_retry(self, request_fn, *args, **kwargs):
+        """
+        Issue a request, blocking and retrying while Discourse responds
+        429, honouring its Retry-After header. Gives up after
+        self.max_rate_limit_retries consecutive 429s and returns that
+        final 429 response, so callers' existing raise_for_status /
+        circuit breaker handling takes over as before.
+        """
+        response = request_fn(*args, **kwargs)
+        retries = 0
+        while (
+            response.status_code == 429
+            and retries < self.max_rate_limit_retries
+        ):
+            delay = _retry_after_seconds(response)
+            retries += 1
+            logger.warning(
+                "Discourse rate-limited %s: blocking and retrying in "
+                "%ss (%s/%s)",
+                getattr(response, "url", None) or "unknown URL",
+                delay,
+                retries,
+                self.max_rate_limit_retries,
+            )
+            time.sleep(delay)
+            response = request_fn(*args, **kwargs)
+        return response
+
+    def _get(self, url, **kwargs):
+        return self._send_with_retry(self.session.get, url, **kwargs)
+
+    def _post(self, url, **kwargs):
+        return self._send_with_retry(self.session.post, url, **kwargs)
 
     def _breaker_guard(self):
         """
@@ -156,7 +221,7 @@ class DiscourseAPI:
         """
 
         def fetch():
-            response = self.session.get(f"{self.base_url}/t/{topic_id}.json")
+            response = self._get(f"{self.base_url}/t/{topic_id}.json")
             response.raise_for_status()
             return response.json()
 
@@ -182,7 +247,7 @@ class DiscourseAPI:
         topics = ",".join([str(i) for i in topic_ids])
 
         def fetch():
-            response = self.session.post(
+            response = self._post(
                 f"{self.base_url}/admin/plugins/explorer/"
                 f"queries/{self.get_topics_query_id}/run",
                 headers=headers,
@@ -216,7 +281,7 @@ class DiscourseAPI:
         """
 
         def fetch():
-            response = self.session.get(
+            response = self._get(
                 f"{self.base_url}/c/{category_id}.json?page={page}"
             )
             response.raise_for_status()
@@ -237,7 +302,7 @@ class DiscourseAPI:
         """
 
         def fetch():
-            response = self.session.get(
+            response = self._get(
                 f"{self.base_url}/discourse-post-event/events.json"
                 f"?include_details=true&limit=100"
             )
@@ -281,7 +346,7 @@ class DiscourseAPI:
         """
 
         def fetch():
-            response = self.session.get(
+            response = self._get(
                 f"{self.base_url}/search.json"
                 f"?q=tags:{tag}&limit={limit}&offset={offset}"
             )
@@ -337,7 +402,7 @@ class DiscourseAPI:
         )
 
         def fetch():
-            response = self.session.post(
+            response = self._post(
                 f"{self.base_url}/admin/plugins/explorer/"
                 f"queries/{data_explorer_id}/run",
                 headers=headers,
@@ -375,7 +440,7 @@ class DiscourseAPI:
             **self._auth_headers,
         }
         params = ({"params": (f'{{"topic_id":"{topic_id}"}} ')},)
-        response = self.session.post(
+        response = self._post(
             f"{self.base_url}/admin/plugins/explorer/"
             f"queries/{data_explorer_id}/run",
             headers=headers,
@@ -404,7 +469,7 @@ class DiscourseAPI:
             **self._auth_headers,
         }
         params = ({"params": (f'{{"category_id":"{category_id}"}} ')},)
-        response = self.session.post(
+        response = self._post(
             f"{self.base_url}/admin/plugins/explorer/"
             f"queries/{data_explorer_id}/run",
             headers=headers,
@@ -559,7 +624,7 @@ class DiscourseAPI:
         params = ({"params": json.dumps(params_dict)},)
 
         def fetch():
-            response = self.session.post(
+            response = self._post(
                 f"{self.base_url}/admin/plugins/explorer/"
                 f"queries/{data_explorer_id}/run",
                 headers=headers,
@@ -622,7 +687,7 @@ class DiscourseAPI:
         params = ({"params": json.dumps(params_dict)},)
 
         def fetch():
-            response = self.session.post(
+            response = self._post(
                 f"{self.base_url}/admin/plugins/explorer/"
                 f"queries/{data_explorer_id}/run",
                 headers=headers,

--- a/canonicalwebteam/discourse/models.py
+++ b/canonicalwebteam/discourse/models.py
@@ -28,7 +28,7 @@ MAX_RETRY_AFTER = 600
 # Safety cap: give up blocking on a single request after this many
 # consecutive 429s, so a persistently rate-limited credential can't
 # hang a request forever. Overridable via DiscourseAPI(...).
-DEFAULT_MAX_RATE_LIMIT_RETRIES = 600
+DEFAULT_MAX_RATE_LIMIT_RETRIES = 10
 
 
 def _retry_after_seconds(response):
@@ -105,9 +105,8 @@ class DiscourseAPI:
         @param max_rate_limit_retries: Every request blocks and retries
             on HTTP 429, honouring Discourse's Retry-After header, for up
             to this many consecutive 429s before giving up and returning
-            the 429 response (default 600 -- effectively "keep retrying
-            for as long as we get 429s", with a safety cap so a request
-            can't hang forever).
+            the 429 response (default 10), so a persistently
+            rate-limited credential can't hang a request forever.
         """
 
         self.base_url = base_url.rstrip("/")

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse",
-    version="7.7.1",
+    version="7.8.0",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical/canonicalwebteam.discourse",

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -180,6 +180,11 @@ class TestDiscourseAPICache(unittest.TestCase):
             api_key="key",
             api_username="user",
             cache=cache,
+            # These tests exercise the cache/breaker path with a mock
+            # session that returns the same 429 forever, not the
+            # blocking retry-on-429 behaviour (covered in
+            # test_models.py), so disable retries to keep them fast.
+            max_rate_limit_retries=0,
         )
         return api, session
 
@@ -417,6 +422,10 @@ class TestBreakerGuardsProbes(unittest.TestCase):
             api_key="key",
             api_username="user",
             cache=cache,
+            # These tests exercise the breaker/immediate-failure path,
+            # not the blocking retry-on-429 behaviour (covered in
+            # test_models.py), so disable retries to keep them fast.
+            max_rate_limit_retries=0,
         )
         return api, session
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -205,5 +205,106 @@ class TestGetEngagePagesByTagMultiTag(unittest.TestCase):
         self.assertEqual(params["tag"], "(?:osm|gsi|cloud)")
 
 
+def _mock_response(status_code, json_data=None, retry_after=None):
+    """
+    A Mock response whose raise_for_status() behaves like a real one:
+    a no-op below 400, an HTTPError (carrying this response) at/above it.
+    """
+    response = unittest.mock.Mock()
+    response.status_code = status_code
+    response.headers = {}
+    if retry_after is not None:
+        response.headers["Retry-After"] = str(retry_after)
+    if status_code >= 400:
+        response.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            response=response
+        )
+    else:
+        response.raise_for_status.return_value = None
+    response.json.return_value = json_data
+    return response
+
+
+class TestRateLimitRetry(unittest.TestCase):
+    """
+    Every request blocks and retries on HTTP 429, honouring Discourse's
+    Retry-After header, until it succeeds or max_rate_limit_retries is
+    exhausted.
+    """
+
+    def _make_api(self, **kwargs):
+        session = unittest.mock.Mock()
+        api = DiscourseAPI(
+            base_url="https://discourse.example.com",
+            session=session,
+            **kwargs,
+        )
+        return api, session
+
+    @unittest.mock.patch("canonicalwebteam.discourse.models.time.sleep")
+    def test_blocks_and_retries_until_success(self, mock_sleep):
+        api, session = self._make_api()
+        session.get.side_effect = [
+            _mock_response(429, retry_after=5),
+            _mock_response(429, retry_after=7),
+            _mock_response(200, json_data={"id": 1, "title": "Retried"}),
+        ]
+
+        topic = api.get_topic(1)
+
+        self.assertEqual(topic, {"id": 1, "title": "Retried"})
+        self.assertEqual(session.get.call_count, 3)
+        mock_sleep.assert_has_calls(
+            [unittest.mock.call(5), unittest.mock.call(7)]
+        )
+
+    @unittest.mock.patch("canonicalwebteam.discourse.models.time.sleep")
+    def test_falls_back_to_default_retry_after_when_header_missing(
+        self, mock_sleep
+    ):
+        api, session = self._make_api()
+        session.get.side_effect = [
+            _mock_response(429),
+            _mock_response(200, json_data={"id": 1}),
+        ]
+
+        api.get_topic(1)
+
+        mock_sleep.assert_called_once_with(60)
+
+    @unittest.mock.patch("canonicalwebteam.discourse.models.time.sleep")
+    def test_retry_after_is_capped(self, mock_sleep):
+        api, session = self._make_api()
+        session.get.side_effect = [
+            _mock_response(429, retry_after=99999),
+            _mock_response(200, json_data={"id": 1}),
+        ]
+
+        api.get_topic(1)
+
+        mock_sleep.assert_called_once_with(600)
+
+    @unittest.mock.patch("canonicalwebteam.discourse.models.time.sleep")
+    def test_gives_up_after_max_rate_limit_retries(self, mock_sleep):
+        api, session = self._make_api(max_rate_limit_retries=2)
+        session.get.return_value = _mock_response(429, retry_after=1)
+
+        with self.assertRaises(requests.exceptions.HTTPError):
+            api.get_topic(1)
+
+        # 1 initial attempt + 2 retries, then give up
+        self.assertEqual(session.get.call_count, 3)
+        self.assertEqual(mock_sleep.call_count, 2)
+
+    def test_zero_retries_fails_immediately_without_sleeping(self):
+        api, session = self._make_api(max_rate_limit_retries=0)
+        session.get.return_value = _mock_response(429)
+
+        with self.assertRaises(requests.exceptions.HTTPError):
+            api.get_topic(1)
+
+        session.get.assert_called_once()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# Done
- Added 10 retries until an error response is returned.

# QA
- Most of the QA for this PR will be done in the following [branch](https://github.com/canonical/ubuntu.com/pull/16582)